### PR TITLE
Corrected a href and removed target blank

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -67,7 +67,7 @@
                 <li><a tabindex="-1" href="https://blogs.apache.org/cloudstack/" target="_blank">Blog<span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
                 <li><a tabindex="-1" href="http://planet.apache.org/cloudstack/" target="_blank">Planet</a></li>
                 <li><a tabindex="-1" href="history.html">History</a></li>
-                <li><a tabindex="-1" href="http://cloudstack.apache.org/software/features.html" target="_blank">Features<span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
+                <li><a tabindex="-1" href="features.html">Features</a></li>
                 <li><a tabindex="-1" href="cloudstack-faq.html">FAQ</a></li>
                 <li><a tabindex="-1" href="who.html">Who We Are</a></li>
                 <li><a tabindex="-1" href="security.html">Security</a></li>


### PR DESCRIPTION
Corrected a href that was 404 and removed the target blank and the external icon as this probably used to be an external link.