### PR TITLE
Python script to generate pmc and commiter list

### DIFF
--- a/makewholist.py
+++ b/makewholist.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""This module can be used to parse and print the PMC and Committer info
+of Apache CloudStack and potentially other ASF projects.
+
+Can be used at command line by running: python makewholist.py"""
+
+import json
+import sys
+import urllib
+
+GROUPS_URL = "https://projects.apache.org/json/foundation/groups.json"
+NAMES_URL = "https://projects.apache.org/json/foundation/people_name.json"
+
+names = {}   # Placeholder for names parsed in getNames()
+groups = {}  # Placeholder for groups parsed in getCommittersAndPMC()
+
+
+def getCommittersAndPMC():
+    """Get Committer and PMC info from ASF"""
+    global groups
+    try:
+        response = urllib.urlopen(GROUPS_URL)
+        groups = json.loads(response.read())
+    except Exception, ex:
+        print "Error during groups JSON download or parsing: %s" % ex.message
+
+
+def getNames():
+    """ Get committer names info from ASF"""
+    global names
+    try:
+        response = urllib.urlopen(NAMES_URL)
+        names = json.loads(response.read())
+    except Exception, ex:
+        print "Error during names JSON download or parsing: %s" % ex.message
+
+
+def printWhoList():
+    if len(names) == 0 or len(groups) == 0:
+        print "Names or groups not initialized, aborting"
+        sys.exit(1)
+
+    print ("Active Project Management Committee contains "
+           "(in alphabetical order of their usernames):")
+
+    print "| Username | Name |"
+    print "|----------|------|"
+    for pmc in groups['cloudstack-pmc']:
+        print "|%s|%s|" % (pmc, names[pmc])
+    print ""
+    print ""
+    print ("Active list of committers "
+           "(in alphabetical order of their usernames):")
+    print "| Username | Name |"
+    print "|----------|------|"
+    for committer in groups['cloudstack']:
+        print "|%s|%s|" % (committer, names[committer])
+
+
+if __name__ == "__main__":
+    getNames()
+    getCommittersAndPMC()
+    printWhoList()


### PR DESCRIPTION
Made a small tool to create pmc and committer list by parsing the JSON
files on projects.apache.org.
This is accessible by anyone and does not require any ASF privileges.

Usage: python makewholist.py

Only dependencies are json, urllib and sys, which should be included by
default on most systems.