### PR TITLE
developer page: fixed some repo links and new tab for external links

### DIFF
--- a/source/developers.markdown
+++ b/source/developers.markdown
@@ -2,8 +2,6 @@
 title: Developer Resources for Apache CloudStack
 ---
 
-Title: Developer Resources for Apache CloudStack
-
 <div class="row">
 
 <div class="col-lg-12">
@@ -26,21 +24,21 @@ Title: Developer Resources for Apache CloudStack
 
 <p>If you're a committer on an Apache project, it means that you can commit directly to the project's repository. For instance, with Apache CloudStack committers are allowed to directly push commits into the git repository.</p>
 
-<p>Non-committers, however, have to submit patches for review. Apache CloudStack accepts <a href="https://github.com">GitHub</a> pull requests. If you are new to Git and GitHub, check these two links:</p>
+<p>Non-committers, however, have to submit patches for review. Apache CloudStack accepts <a href="https://github.com" target="_blank">GitHub</a> pull requests. If you are new to Git and GitHub, check these two links:</p>
 <p>
 <ul>
-  <li><a href="https://try.github.io/levels/1/challenges/1">GitHub 15 minutes </a>tutorial</li>
-  <li><a href="https://help.github.com/articles/creating-a-pull-request/">Creating </a>Pull Requests</li>
+  <li><a href="https://try.github.io/levels/1/challenges/1" target="_blank">GitHub 15 minutes </a>tutorial</li>
+  <li><a href="https://help.github.com/articles/creating-a-pull-request/" target="_blank">Creating </a>Pull Requests</li>
 </ul>
 </p>
 
-<p>Apache CloudStack has a read-only mirror on <a href="https://github.com/apache/cloudstack">GitHub</a> that is kept in sync with the canonical Git repo maintained by the Apache Software Foundation. Submitting GitHub pull requests is the easiest way to get your contribution upstream. For detailed instructions see the link below:</p>
+<p>Apache CloudStack has a read-only mirror on <a href="https://github.com/apache/cloudstack" target="_blank">GitHub</a> that is kept in sync with the canonical Git repo maintained by the Apache Software Foundation. Submitting GitHub pull requests is the easiest way to get your contribution upstream. For detailed instructions see the link below:</p>
 
-<br><a href="https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md">GitHub Contribution Guidelines</a></br>
+<br><a href="https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md" target="_blank">GitHub Contribution Guidelines</a></br>
 
 <h3>Submitting a patch through JIRA</h3>
 
-<p>While we encourage you to submit your contribution through GitHub pull requests, you can also attach a patch in a JIRA ticket. For the purpose of these instructions, we'll assume that you already have a system with <a href="http://git-scm.com/">Git</a> and have found a bug to fix or have a feature that you'd like to submit, and you're willing to contribute that code or documentation under the <a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache License 2.0</a>.</p>
+<p>While we encourage you to submit your contribution through GitHub pull requests, you can also attach a patch in a JIRA ticket. For the purpose of these instructions, we'll assume that you already have a system with <a href="http://git-scm.com/" target="_blank">Git</a> and have found a bug to fix or have a feature that you'd like to submit, and you're willing to contribute that code or documentation under the <a href="http://www.apache.org/licenses/LICENSE-2.0.html" target="_blank">Apache License 2.0</a>.</p>
 
 <p>Further, if you're fixing a bug we'll assume that you've either filed a bug report (where you will attach your patch) or are submitting a fix for a known bug. If you find a bug and would like to fix it, that's awesome! Please be sure to file the bug too, though.</p>
 
@@ -97,7 +95,7 @@ $ git checkout -b mybranch
 
 <h3>Further Reading</h3>
 
-<p>You might want to peruse the <a href="http://www.apache.org/foundation/getinvolved.html">Get Involved</a> page on Apache.org, and the <a href="http://commons.apache.org/patches.html">On Contributing Patches</a> doc as well. Note that some of that does not apply to Apache CloudStack, as we're using git rather than Subversion. But do respect the original style of the CloudStack code, and ensure that you're using spaces rather than tabs, and your patches have Unix line endings (LF) rather than Windows-type line endings (CRLF).</p>
+<p>You might want to peruse the <a href="http://www.apache.org/foundation/getinvolved.html" target="_blank">Get Involved</a> page on Apache.org, and the <a href="http://commons.apache.org/patches.html" target="_blank">On Contributing Patches</a> doc as well. Note that some of that does not apply to Apache CloudStack, as we're using git rather than Subversion. But do respect the original style of the CloudStack code, and ensure that you're using spaces rather than tabs, and your patches have Unix line endings (LF) rather than Windows-type line endings (CRLF).</p>
 
 </div>
 
@@ -108,21 +106,21 @@ $ git checkout -b mybranch
 
 <div class="list-group-item active">Resources</div>
 
-<a href="https://issues.apache.org/jira/browse/CLOUDSTACK" class="list-group-item">Jira</a>
+<a href="https://issues.apache.org/jira/browse/CLOUDSTACK" class="list-group-item" target="_blank">Jira</a>
 
-<a hread="https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md" class="list-group-item">Contribution Guidelines</a>
+<a hread="https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md" class="list-group-item" target="_blank">Contribution Guidelines</a>
 
-<a href="https://builds.apache.org/view/A-D/view/Cloudstack/" class="list-group-item">ASF Jenkins</a>
+<a href="https://builds.apache.org/view/A-D/view/Cloudstack/" class="list-group-item" target="_blank">ASF Jenkins</a>
 
-<a href="http://jenkins.buildacloud.org/" class="list-group-item">CloudStack Jenkins</a>
+<a href="http://jenkins.buildacloud.org/" class="list-group-item" target="_blank">CloudStack Jenkins</a>
 
-<a href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Development+101" class="list-group-item">CloudStack Development 101</a>
+<a href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Development+101" class="list-group-item" target="_blank">CloudStack Development 101</a>
 
-<a href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Setting+up+CloudStack+Development+Environment" class="list-group-item">Setting up a Dev Environment</a>
+<a href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Setting+up+CloudStack+Development+Environment" class="list-group-item" target="_blank">Setting up a Dev Environment</a>
 
-<a href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Coding+conventions" class="list-group-item">Code Conventions</a>
+<a href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Coding+conventions" class="list-group-item" target="_blank">Code Conventions</a>
 
-<a href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Testing" class="list-group-item">Testing CloudStack</a>
+<a href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Testing" class="list-group-item" target="_blank">Testing CloudStack</a>
 
 </div>
 
@@ -141,15 +139,15 @@ $ git checkout -b mybranch
 <p>The git repositories are hosted on Apache infrastructure, and can be found here:</p>
 
 <ul>
-<li><a href="https://git-wip-us.apache.org/repos/asf/cloudstack.git">Apache CloudStack source code</a></li>
-<li><a href="https://git-wip-us.apache.org/repos/asf/cloudstack-cloudmonkey.git">Apache CloudStack Cloudmonkey source code</a></li>
-<li><a href="https://github.com/apache/cloudstack-ec2stack">Apache CloudStack EC2stack Inteface</a></li>
-<li><a href="https://github.com/apache/cloudstack-gcestack">Apache CloudStack GCEstack Interface</a></li>
-<li><a href="https://github.com/apache/cloudstack-docs">General Documentation</a></li>
-<li><a href="https://github.com/apache/cloudstack-docs-install">Installation Guide</a></li>
-<li><a href="://github.com/apache/cloudstack-docs-admin">Administrative Guide</a></li>
-<li><a href="://github.com/apache/cloudstack-docs-rn">Release Notes</a></li>
-<li><a href="://github.com/apache/cloudstack-www">Apache CloudStack Website</a></li>
+<li><a href="https://git-wip-us.apache.org/repos/asf/cloudstack.git" target="_blank">Apache CloudStack source code</a></li>
+<li><a href="https://git-wip-us.apache.org/repos/asf/cloudstack-cloudmonkey.git" target="_blank">Apache CloudStack Cloudmonkey source code</a></li>
+<li><a href="https://github.com/apache/cloudstack-ec2stack" target="_blank">Apache CloudStack EC2stack Inteface</a></li>
+<li><a href="https://github.com/apache/cloudstack-gcestack" target="_blank">Apache CloudStack GCEstack Interface</a></li>
+<li><a href="https://github.com/apache/cloudstack-docs" target="_blank">General Documentation</a></li>
+<li><a href="https://github.com/apache/cloudstack-docs-install" target="_blank">Installation Guide</a></li>
+<li><a href="https://github.com/apache/cloudstack-docs-admin" target="_blank">Administrative Guide</a></li>
+<li><a href="https://github.com/apache/cloudstack-docs-rn" target="_blank">Release Notes</a></li>
+<li><a href="https://github.com/apache/cloudstack-www" target="_blank">Apache CloudStack Website</a></li>
 </ul>
 
 <p>To get the most recent source for Apache CloudStack, use:</p>
@@ -160,7 +158,7 @@ git clone https://git-wip-us.apache.org/repos/asf/cloudstack.git
 
 <p>Similarly, clone the cloudstack-cloudmonkey repository or the other repositories to get access to the most recent source of all CloudStack subprojects.</p>
 
-<p>For projects related to Apache CloudStack but not under ASF governance, see the <a href="https://github.com/cloudstack-extras">CloudStack-extras repositories on GitHub</a>.</p>
+<p>For projects related to Apache CloudStack but not under ASF governance, see the <a href="https://github.com/cloudstack-extras" target="_blank">CloudStack-extras repositories on GitHub</a>.</p>
               
 </div>
             


### PR DESCRIPTION
Fixed repo links as they were broken before.

I also changed the external links on this page to be opened in new tabs so it preserves the flow for the developer as they go through the guide and click to learn more about different topics as they work their way through the guide.