### PR TITLE
Remove link to “planet.apache.org” and update conference links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,42 @@ Build the site with:
 To serve it locally:
 
     $ middleman server
+	
+#Building
+To build the HTML files, you just need to execute the `build.sh`. The script will automatically generate the HTML files and then move them to the `content` folder.
 
-IMPORTANT: To publish your changes, commit the build into the asf-site * branch *
+# Commiting 
+Use GitHub PR to make changes. **No one should commit directly to Apache remote repositories without opening a PR and waiting for proper review**.
+If you got the feedback and have amended the changes (if needed), it is time to **commit** the changes to **Apache Software Foundation (AFS) remote repository**. The ASF remote repository for this project is: `https://git-wip-us.apache.org/repos/asf/cloudstack-www.git`
 
-GOTCHA, *TODO*, the `build` directory needs to be renamed `content` in the asf-site branch for the site to be served properly.
+**IMPORTANT:** To publish your changes, you should commit into the **asf-site** branch (pay attention, this is the name of the branch in the remote repository). **Do not forget**, you also have to commit the same changes to the master; so, **master** and **asf-site** branches are synchronized.
 
-*TODO* check the `build.sh` script and make it better, simple build that stages all changes to `/content`
+The **asf-site** branch is synchronized with a web server that delivers the Apache CloudStack web pages.
 
-Use GitHub PR to make changes.
+GOTCHA, the `build` directory needs to be renamed to `content` in the asf-site branch for the site to be served properly; If you use the `build.sh` script, this step is already taken care of.
 
-*TODO* Add gitHUB PR contribution instructions and better build instructions for committers
-
+## Step by step
+* Fork the repo to your own Github: `<your_github_user>`. To do that, you can access `https://github.com/apache/cloudstack-www` and click on `fork` on the right upper corner of the page.
+* Then, you can clone to you local git repo using: `git clone`; e.g. `git clone https://github.com/apache/cloudstack-www.git` or `git clone https://github.com/<your_github_user>/cloudstack-www.git`
+* `cd cloudstack-www`
+* __This step is only required for committers:__ (add the ASF remote repo) `git remote add upstream https://git-wip-us.apache.org/repos/asf/cloudstack-www.git`
+* if you have cloned  directly from Apache namespace on Github, then you need to add your namespace on Github as well, `git remote add <your_github_user> https://github.com/<your_github_user>/cloudstack-www.git`
+* (get the master branch): `git checkout -b master origin/master` or `git checkout -b master <your_github_user>/master`
+* Now, it is your turn to make the changes you want
+* `middleman build` will build/"compile" the HTML files from the sources
+* ` middleman server [-p <portnumber>]`. This will serve/deliver your HTML files over HTTP. You just gotta access them using a browser; e.g. `http://localhost:[port_configured]`. **Check your changes!!**
+* Execute `./build.sh`
+* `git add -A`
+* `git commit -am "your commit message"`
+* `git push `<your_github_user>` master`
+* Check if the changes appear properly on your Github project, and then create a PR against the Apache `cloudstack-www` repo.
+* Get feedback on the PR and proceed once PR review is accepted
+* If you are not a committer, your job finishes here. Congratulations you have made the Apache CloudStack website better  :thumbsup:
+* Continuing, for committers. Clone or add the repo of our contributor on Github using `git remote add <friend_contributor> https://github.com/<friend_contributor>/cloudstack-www.git`
+* `git checkout asf-site`
+* `git merge <repo_where_the_changes_are>/master`; e.g. `git merge <friend_contributor>/master` or `git merge <your_github_user>/master`
+* `git log -p`. Check if the changes were properly merged.
+* `git push upstream asf-site`
+* `git push upstream master`
+* The site will automatically be published live. This should not take long; if the changes are not showing up, check your browser cache. If changes do not show up and you have no idea why, call someone on `devs` mailing list.
+* Verify the changes on the live site. After this, your job is done, thank you very much for helping to improve the Apache CloudStack website :thumbsup:

--- a/content/about.html
+++ b/content/about.html
@@ -65,7 +65,6 @@
                 <li><a tabindex="-1" href="about.html">About</a></li>
                 <li class="divider"></li>
                 <li><a tabindex="-1" href="https://blogs.apache.org/cloudstack/" target="_blank">Blog<span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
-                <li><a tabindex="-1" href="http://planet.apache.org/cloudstack/" target="_blank">Planet</a></li>
                 <li><a tabindex="-1" href="history.html">History</a></li>
                 <li><a tabindex="-1" href="features.html">Features</a></li>
                 <li><a tabindex="-1" href="cloudstack-faq.html">FAQ</a></li>
@@ -79,7 +78,7 @@
                 <li><a tabindex="-1" href="contribute.html">Get Involved</a></li>
                 <li><a tabindex="-1" href="developers.html">Developers</a></li>
                 <li><a tabindex="-1" href="mailing-lists.html">Mailing Lists</a></li>
-                <li><a tabindex="-1" href="http://lanyrd.com/topics/apache-cloudstack/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
+                <li><a tabindex="-1" href="http://cloudstackcollab.org/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/api.html
+++ b/content/api.html
@@ -65,7 +65,6 @@
                 <li><a tabindex="-1" href="about.html">About</a></li>
                 <li class="divider"></li>
                 <li><a tabindex="-1" href="https://blogs.apache.org/cloudstack/" target="_blank">Blog<span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
-                <li><a tabindex="-1" href="http://planet.apache.org/cloudstack/" target="_blank">Planet</a></li>
                 <li><a tabindex="-1" href="history.html">History</a></li>
                 <li><a tabindex="-1" href="features.html">Features</a></li>
                 <li><a tabindex="-1" href="cloudstack-faq.html">FAQ</a></li>
@@ -79,7 +78,7 @@
                 <li><a tabindex="-1" href="contribute.html">Get Involved</a></li>
                 <li><a tabindex="-1" href="developers.html">Developers</a></li>
                 <li><a tabindex="-1" href="mailing-lists.html">Mailing Lists</a></li>
-                <li><a tabindex="-1" href="http://lanyrd.com/topics/apache-cloudstack/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
+                <li><a tabindex="-1" href="http://cloudstackcollab.org/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/api_archives.html
+++ b/content/api_archives.html
@@ -65,7 +65,6 @@
                 <li><a tabindex="-1" href="about.html">About</a></li>
                 <li class="divider"></li>
                 <li><a tabindex="-1" href="https://blogs.apache.org/cloudstack/" target="_blank">Blog<span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
-                <li><a tabindex="-1" href="http://planet.apache.org/cloudstack/" target="_blank">Planet</a></li>
                 <li><a tabindex="-1" href="history.html">History</a></li>
                 <li><a tabindex="-1" href="features.html">Features</a></li>
                 <li><a tabindex="-1" href="cloudstack-faq.html">FAQ</a></li>
@@ -79,7 +78,7 @@
                 <li><a tabindex="-1" href="contribute.html">Get Involved</a></li>
                 <li><a tabindex="-1" href="developers.html">Developers</a></li>
                 <li><a tabindex="-1" href="mailing-lists.html">Mailing Lists</a></li>
-                <li><a tabindex="-1" href="http://lanyrd.com/topics/apache-cloudstack/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
+                <li><a tabindex="-1" href="http://cloudstackcollab.org/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/archives.html
+++ b/content/archives.html
@@ -65,7 +65,6 @@
                 <li><a tabindex="-1" href="about.html">About</a></li>
                 <li class="divider"></li>
                 <li><a tabindex="-1" href="https://blogs.apache.org/cloudstack/" target="_blank">Blog<span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
-                <li><a tabindex="-1" href="http://planet.apache.org/cloudstack/" target="_blank">Planet</a></li>
                 <li><a tabindex="-1" href="history.html">History</a></li>
                 <li><a tabindex="-1" href="features.html">Features</a></li>
                 <li><a tabindex="-1" href="cloudstack-faq.html">FAQ</a></li>
@@ -79,7 +78,7 @@
                 <li><a tabindex="-1" href="contribute.html">Get Involved</a></li>
                 <li><a tabindex="-1" href="developers.html">Developers</a></li>
                 <li><a tabindex="-1" href="mailing-lists.html">Mailing Lists</a></li>
-                <li><a tabindex="-1" href="http://lanyrd.com/topics/apache-cloudstack/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
+                <li><a tabindex="-1" href="http://cloudstackcollab.org/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/bylaws.html
+++ b/content/bylaws.html
@@ -65,7 +65,6 @@
                 <li><a tabindex="-1" href="about.html">About</a></li>
                 <li class="divider"></li>
                 <li><a tabindex="-1" href="https://blogs.apache.org/cloudstack/" target="_blank">Blog<span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
-                <li><a tabindex="-1" href="http://planet.apache.org/cloudstack/" target="_blank">Planet</a></li>
                 <li><a tabindex="-1" href="history.html">History</a></li>
                 <li><a tabindex="-1" href="features.html">Features</a></li>
                 <li><a tabindex="-1" href="cloudstack-faq.html">FAQ</a></li>
@@ -79,7 +78,7 @@
                 <li><a tabindex="-1" href="contribute.html">Get Involved</a></li>
                 <li><a tabindex="-1" href="developers.html">Developers</a></li>
                 <li><a tabindex="-1" href="mailing-lists.html">Mailing Lists</a></li>
-                <li><a tabindex="-1" href="http://lanyrd.com/topics/apache-cloudstack/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
+                <li><a tabindex="-1" href="http://cloudstackcollab.org/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/cloudstack-faq.html
+++ b/content/cloudstack-faq.html
@@ -65,7 +65,6 @@
                 <li><a tabindex="-1" href="about.html">About</a></li>
                 <li class="divider"></li>
                 <li><a tabindex="-1" href="https://blogs.apache.org/cloudstack/" target="_blank">Blog<span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
-                <li><a tabindex="-1" href="http://planet.apache.org/cloudstack/" target="_blank">Planet</a></li>
                 <li><a tabindex="-1" href="history.html">History</a></li>
                 <li><a tabindex="-1" href="features.html">Features</a></li>
                 <li><a tabindex="-1" href="cloudstack-faq.html">FAQ</a></li>
@@ -79,7 +78,7 @@
                 <li><a tabindex="-1" href="contribute.html">Get Involved</a></li>
                 <li><a tabindex="-1" href="developers.html">Developers</a></li>
                 <li><a tabindex="-1" href="mailing-lists.html">Mailing Lists</a></li>
-                <li><a tabindex="-1" href="http://lanyrd.com/topics/apache-cloudstack/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
+                <li><a tabindex="-1" href="http://cloudstackcollab.org/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/contribute.html
+++ b/content/contribute.html
@@ -65,7 +65,6 @@
                 <li><a tabindex="-1" href="about.html">About</a></li>
                 <li class="divider"></li>
                 <li><a tabindex="-1" href="https://blogs.apache.org/cloudstack/" target="_blank">Blog<span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
-                <li><a tabindex="-1" href="http://planet.apache.org/cloudstack/" target="_blank">Planet</a></li>
                 <li><a tabindex="-1" href="history.html">History</a></li>
                 <li><a tabindex="-1" href="features.html">Features</a></li>
                 <li><a tabindex="-1" href="cloudstack-faq.html">FAQ</a></li>
@@ -79,7 +78,7 @@
                 <li><a tabindex="-1" href="contribute.html">Get Involved</a></li>
                 <li><a tabindex="-1" href="developers.html">Developers</a></li>
                 <li><a tabindex="-1" href="mailing-lists.html">Mailing Lists</a></li>
-                <li><a tabindex="-1" href="http://lanyrd.com/topics/apache-cloudstack/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
+                <li><a tabindex="-1" href="http://cloudstackcollab.org/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/developers.html
+++ b/content/developers.html
@@ -65,7 +65,6 @@
                 <li><a tabindex="-1" href="about.html">About</a></li>
                 <li class="divider"></li>
                 <li><a tabindex="-1" href="https://blogs.apache.org/cloudstack/" target="_blank">Blog<span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
-                <li><a tabindex="-1" href="http://planet.apache.org/cloudstack/" target="_blank">Planet</a></li>
                 <li><a tabindex="-1" href="history.html">History</a></li>
                 <li><a tabindex="-1" href="features.html">Features</a></li>
                 <li><a tabindex="-1" href="cloudstack-faq.html">FAQ</a></li>
@@ -79,7 +78,7 @@
                 <li><a tabindex="-1" href="contribute.html">Get Involved</a></li>
                 <li><a tabindex="-1" href="developers.html">Developers</a></li>
                 <li><a tabindex="-1" href="mailing-lists.html">Mailing Lists</a></li>
-                <li><a tabindex="-1" href="http://lanyrd.com/topics/apache-cloudstack/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
+                <li><a tabindex="-1" href="http://cloudstackcollab.org/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -65,7 +65,6 @@
                 <li><a tabindex="-1" href="about.html">About</a></li>
                 <li class="divider"></li>
                 <li><a tabindex="-1" href="https://blogs.apache.org/cloudstack/" target="_blank">Blog<span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
-                <li><a tabindex="-1" href="http://planet.apache.org/cloudstack/" target="_blank">Planet</a></li>
                 <li><a tabindex="-1" href="history.html">History</a></li>
                 <li><a tabindex="-1" href="features.html">Features</a></li>
                 <li><a tabindex="-1" href="cloudstack-faq.html">FAQ</a></li>
@@ -79,7 +78,7 @@
                 <li><a tabindex="-1" href="contribute.html">Get Involved</a></li>
                 <li><a tabindex="-1" href="developers.html">Developers</a></li>
                 <li><a tabindex="-1" href="mailing-lists.html">Mailing Lists</a></li>
-                <li><a tabindex="-1" href="http://lanyrd.com/topics/apache-cloudstack/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
+                <li><a tabindex="-1" href="http://cloudstackcollab.org/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/features.html
+++ b/content/features.html
@@ -65,7 +65,6 @@
                 <li><a tabindex="-1" href="about.html">About</a></li>
                 <li class="divider"></li>
                 <li><a tabindex="-1" href="https://blogs.apache.org/cloudstack/" target="_blank">Blog<span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
-                <li><a tabindex="-1" href="http://planet.apache.org/cloudstack/" target="_blank">Planet</a></li>
                 <li><a tabindex="-1" href="history.html">History</a></li>
                 <li><a tabindex="-1" href="features.html">Features</a></li>
                 <li><a tabindex="-1" href="cloudstack-faq.html">FAQ</a></li>
@@ -79,7 +78,7 @@
                 <li><a tabindex="-1" href="contribute.html">Get Involved</a></li>
                 <li><a tabindex="-1" href="developers.html">Developers</a></li>
                 <li><a tabindex="-1" href="mailing-lists.html">Mailing Lists</a></li>
-                <li><a tabindex="-1" href="http://lanyrd.com/topics/apache-cloudstack/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
+                <li><a tabindex="-1" href="http://cloudstackcollab.org/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/history.html
+++ b/content/history.html
@@ -65,7 +65,6 @@
                 <li><a tabindex="-1" href="about.html">About</a></li>
                 <li class="divider"></li>
                 <li><a tabindex="-1" href="https://blogs.apache.org/cloudstack/" target="_blank">Blog<span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
-                <li><a tabindex="-1" href="http://planet.apache.org/cloudstack/" target="_blank">Planet</a></li>
                 <li><a tabindex="-1" href="history.html">History</a></li>
                 <li><a tabindex="-1" href="features.html">Features</a></li>
                 <li><a tabindex="-1" href="cloudstack-faq.html">FAQ</a></li>
@@ -79,7 +78,7 @@
                 <li><a tabindex="-1" href="contribute.html">Get Involved</a></li>
                 <li><a tabindex="-1" href="developers.html">Developers</a></li>
                 <li><a tabindex="-1" href="mailing-lists.html">Mailing Lists</a></li>
-                <li><a tabindex="-1" href="http://lanyrd.com/topics/apache-cloudstack/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
+                <li><a tabindex="-1" href="http://cloudstackcollab.org/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/index.html
+++ b/content/index.html
@@ -65,7 +65,6 @@
                 <li><a tabindex="-1" href="about.html">About</a></li>
                 <li class="divider"></li>
                 <li><a tabindex="-1" href="https://blogs.apache.org/cloudstack/" target="_blank">Blog<span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
-                <li><a tabindex="-1" href="http://planet.apache.org/cloudstack/" target="_blank">Planet</a></li>
                 <li><a tabindex="-1" href="history.html">History</a></li>
                 <li><a tabindex="-1" href="features.html">Features</a></li>
                 <li><a tabindex="-1" href="cloudstack-faq.html">FAQ</a></li>
@@ -79,7 +78,7 @@
                 <li><a tabindex="-1" href="contribute.html">Get Involved</a></li>
                 <li><a tabindex="-1" href="developers.html">Developers</a></li>
                 <li><a tabindex="-1" href="mailing-lists.html">Mailing Lists</a></li>
-                <li><a tabindex="-1" href="http://lanyrd.com/topics/apache-cloudstack/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
+                <li><a tabindex="-1" href="http://cloudstackcollab.org/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/mailing-lists.html
+++ b/content/mailing-lists.html
@@ -65,7 +65,6 @@
                 <li><a tabindex="-1" href="about.html">About</a></li>
                 <li class="divider"></li>
                 <li><a tabindex="-1" href="https://blogs.apache.org/cloudstack/" target="_blank">Blog<span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
-                <li><a tabindex="-1" href="http://planet.apache.org/cloudstack/" target="_blank">Planet</a></li>
                 <li><a tabindex="-1" href="history.html">History</a></li>
                 <li><a tabindex="-1" href="features.html">Features</a></li>
                 <li><a tabindex="-1" href="cloudstack-faq.html">FAQ</a></li>
@@ -79,7 +78,7 @@
                 <li><a tabindex="-1" href="contribute.html">Get Involved</a></li>
                 <li><a tabindex="-1" href="developers.html">Developers</a></li>
                 <li><a tabindex="-1" href="mailing-lists.html">Mailing Lists</a></li>
-                <li><a tabindex="-1" href="http://lanyrd.com/topics/apache-cloudstack/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
+                <li><a tabindex="-1" href="http://cloudstackcollab.org/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/security.html
+++ b/content/security.html
@@ -65,7 +65,6 @@
                 <li><a tabindex="-1" href="about.html">About</a></li>
                 <li class="divider"></li>
                 <li><a tabindex="-1" href="https://blogs.apache.org/cloudstack/" target="_blank">Blog<span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
-                <li><a tabindex="-1" href="http://planet.apache.org/cloudstack/" target="_blank">Planet</a></li>
                 <li><a tabindex="-1" href="history.html">History</a></li>
                 <li><a tabindex="-1" href="features.html">Features</a></li>
                 <li><a tabindex="-1" href="cloudstack-faq.html">FAQ</a></li>
@@ -79,7 +78,7 @@
                 <li><a tabindex="-1" href="contribute.html">Get Involved</a></li>
                 <li><a tabindex="-1" href="developers.html">Developers</a></li>
                 <li><a tabindex="-1" href="mailing-lists.html">Mailing Lists</a></li>
-                <li><a tabindex="-1" href="http://lanyrd.com/topics/apache-cloudstack/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
+                <li><a tabindex="-1" href="http://cloudstackcollab.org/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/software.html
+++ b/content/software.html
@@ -65,7 +65,6 @@
                 <li><a tabindex="-1" href="about.html">About</a></li>
                 <li class="divider"></li>
                 <li><a tabindex="-1" href="https://blogs.apache.org/cloudstack/" target="_blank">Blog<span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
-                <li><a tabindex="-1" href="http://planet.apache.org/cloudstack/" target="_blank">Planet</a></li>
                 <li><a tabindex="-1" href="history.html">History</a></li>
                 <li><a tabindex="-1" href="features.html">Features</a></li>
                 <li><a tabindex="-1" href="cloudstack-faq.html">FAQ</a></li>
@@ -79,7 +78,7 @@
                 <li><a tabindex="-1" href="contribute.html">Get Involved</a></li>
                 <li><a tabindex="-1" href="developers.html">Developers</a></li>
                 <li><a tabindex="-1" href="mailing-lists.html">Mailing Lists</a></li>
-                <li><a tabindex="-1" href="http://lanyrd.com/topics/apache-cloudstack/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
+                <li><a tabindex="-1" href="http://cloudstackcollab.org/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/survey.html
+++ b/content/survey.html
@@ -65,7 +65,6 @@
                 <li><a tabindex="-1" href="about.html">About</a></li>
                 <li class="divider"></li>
                 <li><a tabindex="-1" href="https://blogs.apache.org/cloudstack/" target="_blank">Blog<span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
-                <li><a tabindex="-1" href="http://planet.apache.org/cloudstack/" target="_blank">Planet</a></li>
                 <li><a tabindex="-1" href="history.html">History</a></li>
                 <li><a tabindex="-1" href="features.html">Features</a></li>
                 <li><a tabindex="-1" href="cloudstack-faq.html">FAQ</a></li>
@@ -79,7 +78,7 @@
                 <li><a tabindex="-1" href="contribute.html">Get Involved</a></li>
                 <li><a tabindex="-1" href="developers.html">Developers</a></li>
                 <li><a tabindex="-1" href="mailing-lists.html">Mailing Lists</a></li>
-                <li><a tabindex="-1" href="http://lanyrd.com/topics/apache-cloudstack/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
+                <li><a tabindex="-1" href="http://cloudstackcollab.org/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/trademark-guidelines.html
+++ b/content/trademark-guidelines.html
@@ -65,7 +65,6 @@
                 <li><a tabindex="-1" href="about.html">About</a></li>
                 <li class="divider"></li>
                 <li><a tabindex="-1" href="https://blogs.apache.org/cloudstack/" target="_blank">Blog<span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
-                <li><a tabindex="-1" href="http://planet.apache.org/cloudstack/" target="_blank">Planet</a></li>
                 <li><a tabindex="-1" href="history.html">History</a></li>
                 <li><a tabindex="-1" href="features.html">Features</a></li>
                 <li><a tabindex="-1" href="cloudstack-faq.html">FAQ</a></li>
@@ -79,7 +78,7 @@
                 <li><a tabindex="-1" href="contribute.html">Get Involved</a></li>
                 <li><a tabindex="-1" href="developers.html">Developers</a></li>
                 <li><a tabindex="-1" href="mailing-lists.html">Mailing Lists</a></li>
-                <li><a tabindex="-1" href="http://lanyrd.com/topics/apache-cloudstack/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
+                <li><a tabindex="-1" href="http://cloudstackcollab.org/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/users.html
+++ b/content/users.html
@@ -65,7 +65,6 @@
                 <li><a tabindex="-1" href="about.html">About</a></li>
                 <li class="divider"></li>
                 <li><a tabindex="-1" href="https://blogs.apache.org/cloudstack/" target="_blank">Blog<span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
-                <li><a tabindex="-1" href="http://planet.apache.org/cloudstack/" target="_blank">Planet</a></li>
                 <li><a tabindex="-1" href="history.html">History</a></li>
                 <li><a tabindex="-1" href="features.html">Features</a></li>
                 <li><a tabindex="-1" href="cloudstack-faq.html">FAQ</a></li>
@@ -79,7 +78,7 @@
                 <li><a tabindex="-1" href="contribute.html">Get Involved</a></li>
                 <li><a tabindex="-1" href="developers.html">Developers</a></li>
                 <li><a tabindex="-1" href="mailing-lists.html">Mailing Lists</a></li>
-                <li><a tabindex="-1" href="http://lanyrd.com/topics/apache-cloudstack/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
+                <li><a tabindex="-1" href="http://cloudstackcollab.org/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/videos.html
+++ b/content/videos.html
@@ -65,7 +65,6 @@
                 <li><a tabindex="-1" href="about.html">About</a></li>
                 <li class="divider"></li>
                 <li><a tabindex="-1" href="https://blogs.apache.org/cloudstack/" target="_blank">Blog<span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
-                <li><a tabindex="-1" href="http://planet.apache.org/cloudstack/" target="_blank">Planet</a></li>
                 <li><a tabindex="-1" href="history.html">History</a></li>
                 <li><a tabindex="-1" href="features.html">Features</a></li>
                 <li><a tabindex="-1" href="cloudstack-faq.html">FAQ</a></li>
@@ -79,7 +78,7 @@
                 <li><a tabindex="-1" href="contribute.html">Get Involved</a></li>
                 <li><a tabindex="-1" href="developers.html">Developers</a></li>
                 <li><a tabindex="-1" href="mailing-lists.html">Mailing Lists</a></li>
-                <li><a tabindex="-1" href="http://lanyrd.com/topics/apache-cloudstack/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
+                <li><a tabindex="-1" href="http://cloudstackcollab.org/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/who.html
+++ b/content/who.html
@@ -65,7 +65,6 @@
                 <li><a tabindex="-1" href="about.html">About</a></li>
                 <li class="divider"></li>
                 <li><a tabindex="-1" href="https://blogs.apache.org/cloudstack/" target="_blank">Blog<span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
-                <li><a tabindex="-1" href="http://planet.apache.org/cloudstack/" target="_blank">Planet</a></li>
                 <li><a tabindex="-1" href="history.html">History</a></li>
                 <li><a tabindex="-1" href="features.html">Features</a></li>
                 <li><a tabindex="-1" href="cloudstack-faq.html">FAQ</a></li>
@@ -79,7 +78,7 @@
                 <li><a tabindex="-1" href="contribute.html">Get Involved</a></li>
                 <li><a tabindex="-1" href="developers.html">Developers</a></li>
                 <li><a tabindex="-1" href="mailing-lists.html">Mailing Lists</a></li>
-                <li><a tabindex="-1" href="http://lanyrd.com/topics/apache-cloudstack/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
+                <li><a tabindex="-1" href="http://cloudstackcollab.org/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -65,7 +65,6 @@
                 <li><a tabindex="-1" href="about.html">About</a></li>
                 <li class="divider"></li>
                 <li><a tabindex="-1" href="https://blogs.apache.org/cloudstack/" target="_blank">Blog<span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
-                <li><a tabindex="-1" href="http://planet.apache.org/cloudstack/" target="_blank">Planet</a></li>
                 <li><a tabindex="-1" href="history.html">History</a></li>
                 <li><a tabindex="-1" href="features.html">Features</a></li>
                 <li><a tabindex="-1" href="cloudstack-faq.html">FAQ</a></li>
@@ -79,7 +78,7 @@
                 <li><a tabindex="-1" href="contribute.html">Get Involved</a></li>
                 <li><a tabindex="-1" href="developers.html">Developers</a></li>
                 <li><a tabindex="-1" href="mailing-lists.html">Mailing Lists</a></li>
-                <li><a tabindex="-1" href="http://lanyrd.com/topics/apache-cloudstack/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
+                <li><a tabindex="-1" href="http://cloudstackcollab.org/" target="_blank">Events &amp; Meetups <span class="glyphicon glyphicon-share-alt pull-right"></span></a></li>
               </ul>
             </li>
             <li class="dropdown">


### PR DESCRIPTION
Remove link to “planet.apache.org” and update conference links and update the link for the CCCs hot site