### PR TITLE
Restructure Docs dropdown to use consolidated Doc site and show archived Docs

### DIFF
--- a/content/about.html
+++ b/content/about.html
@@ -93,13 +93,16 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="docs">Documentation <span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="docs">
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">Getting Started Docs</span></a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-installation" target="_blank">Installation Docs</a></li> 
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-administration" target="_blank">Administration Docs</a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-release-notes" target="_blank">Release Notes</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">CloudStack Documentation</span></a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Home" target="_blank">Wiki</a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+Books" target="_blank">Books</a></li>
                 <li><a tabindex="-1" href="api.html">API Documentation</a></li>
+                <li class="divider"></li>
+                <li><a tabindex="-1">Archived Documentation</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started" target="_blank">&nbsp;&nbsp;&nbsp;Getting Started Docs</span></a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-installation" target="_blank">&nbsp;&nbsp;&nbsp;Installation Docs</a></li> 
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-administration" target="_blank">&nbsp;&nbsp;&nbsp;Administration Docs</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-release-notes" target="_blank">&nbsp;&nbsp;&nbsp;Release Notes</a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/api.html
+++ b/content/api.html
@@ -93,13 +93,16 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="docs">Documentation <span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="docs">
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">Getting Started Docs</span></a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-installation" target="_blank">Installation Docs</a></li> 
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-administration" target="_blank">Administration Docs</a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-release-notes" target="_blank">Release Notes</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">CloudStack Documentation</span></a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Home" target="_blank">Wiki</a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+Books" target="_blank">Books</a></li>
                 <li><a tabindex="-1" href="api.html">API Documentation</a></li>
+                <li class="divider"></li>
+                <li><a tabindex="-1">Archived Documentation</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started" target="_blank">&nbsp;&nbsp;&nbsp;Getting Started Docs</span></a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-installation" target="_blank">&nbsp;&nbsp;&nbsp;Installation Docs</a></li> 
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-administration" target="_blank">&nbsp;&nbsp;&nbsp;Administration Docs</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-release-notes" target="_blank">&nbsp;&nbsp;&nbsp;Release Notes</a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/api_archives.html
+++ b/content/api_archives.html
@@ -93,13 +93,16 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="docs">Documentation <span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="docs">
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">Getting Started Docs</span></a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-installation" target="_blank">Installation Docs</a></li> 
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-administration" target="_blank">Administration Docs</a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-release-notes" target="_blank">Release Notes</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">CloudStack Documentation</span></a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Home" target="_blank">Wiki</a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+Books" target="_blank">Books</a></li>
                 <li><a tabindex="-1" href="api.html">API Documentation</a></li>
+                <li class="divider"></li>
+                <li><a tabindex="-1">Archived Documentation</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started" target="_blank">&nbsp;&nbsp;&nbsp;Getting Started Docs</span></a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-installation" target="_blank">&nbsp;&nbsp;&nbsp;Installation Docs</a></li> 
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-administration" target="_blank">&nbsp;&nbsp;&nbsp;Administration Docs</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-release-notes" target="_blank">&nbsp;&nbsp;&nbsp;Release Notes</a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/archives.html
+++ b/content/archives.html
@@ -93,13 +93,16 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="docs">Documentation <span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="docs">
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">Getting Started Docs</span></a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-installation" target="_blank">Installation Docs</a></li> 
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-administration" target="_blank">Administration Docs</a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-release-notes" target="_blank">Release Notes</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">CloudStack Documentation</span></a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Home" target="_blank">Wiki</a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+Books" target="_blank">Books</a></li>
                 <li><a tabindex="-1" href="api.html">API Documentation</a></li>
+                <li class="divider"></li>
+                <li><a tabindex="-1">Archived Documentation</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started" target="_blank">&nbsp;&nbsp;&nbsp;Getting Started Docs</span></a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-installation" target="_blank">&nbsp;&nbsp;&nbsp;Installation Docs</a></li> 
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-administration" target="_blank">&nbsp;&nbsp;&nbsp;Administration Docs</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-release-notes" target="_blank">&nbsp;&nbsp;&nbsp;Release Notes</a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/bylaws.html
+++ b/content/bylaws.html
@@ -93,13 +93,16 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="docs">Documentation <span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="docs">
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">Getting Started Docs</span></a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-installation" target="_blank">Installation Docs</a></li> 
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-administration" target="_blank">Administration Docs</a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-release-notes" target="_blank">Release Notes</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">CloudStack Documentation</span></a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Home" target="_blank">Wiki</a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+Books" target="_blank">Books</a></li>
                 <li><a tabindex="-1" href="api.html">API Documentation</a></li>
+                <li class="divider"></li>
+                <li><a tabindex="-1">Archived Documentation</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started" target="_blank">&nbsp;&nbsp;&nbsp;Getting Started Docs</span></a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-installation" target="_blank">&nbsp;&nbsp;&nbsp;Installation Docs</a></li> 
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-administration" target="_blank">&nbsp;&nbsp;&nbsp;Administration Docs</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-release-notes" target="_blank">&nbsp;&nbsp;&nbsp;Release Notes</a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/cloudstack-faq.html
+++ b/content/cloudstack-faq.html
@@ -93,13 +93,16 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="docs">Documentation <span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="docs">
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">Getting Started Docs</span></a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-installation" target="_blank">Installation Docs</a></li> 
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-administration" target="_blank">Administration Docs</a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-release-notes" target="_blank">Release Notes</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">CloudStack Documentation</span></a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Home" target="_blank">Wiki</a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+Books" target="_blank">Books</a></li>
                 <li><a tabindex="-1" href="api.html">API Documentation</a></li>
+                <li class="divider"></li>
+                <li><a tabindex="-1">Archived Documentation</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started" target="_blank">&nbsp;&nbsp;&nbsp;Getting Started Docs</span></a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-installation" target="_blank">&nbsp;&nbsp;&nbsp;Installation Docs</a></li> 
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-administration" target="_blank">&nbsp;&nbsp;&nbsp;Administration Docs</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-release-notes" target="_blank">&nbsp;&nbsp;&nbsp;Release Notes</a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/contribute.html
+++ b/content/contribute.html
@@ -93,13 +93,16 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="docs">Documentation <span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="docs">
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">Getting Started Docs</span></a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-installation" target="_blank">Installation Docs</a></li> 
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-administration" target="_blank">Administration Docs</a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-release-notes" target="_blank">Release Notes</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">CloudStack Documentation</span></a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Home" target="_blank">Wiki</a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+Books" target="_blank">Books</a></li>
                 <li><a tabindex="-1" href="api.html">API Documentation</a></li>
+                <li class="divider"></li>
+                <li><a tabindex="-1">Archived Documentation</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started" target="_blank">&nbsp;&nbsp;&nbsp;Getting Started Docs</span></a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-installation" target="_blank">&nbsp;&nbsp;&nbsp;Installation Docs</a></li> 
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-administration" target="_blank">&nbsp;&nbsp;&nbsp;Administration Docs</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-release-notes" target="_blank">&nbsp;&nbsp;&nbsp;Release Notes</a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/developers.html
+++ b/content/developers.html
@@ -93,13 +93,16 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="docs">Documentation <span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="docs">
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">Getting Started Docs</span></a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-installation" target="_blank">Installation Docs</a></li> 
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-administration" target="_blank">Administration Docs</a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-release-notes" target="_blank">Release Notes</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">CloudStack Documentation</span></a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Home" target="_blank">Wiki</a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+Books" target="_blank">Books</a></li>
                 <li><a tabindex="-1" href="api.html">API Documentation</a></li>
+                <li class="divider"></li>
+                <li><a tabindex="-1">Archived Documentation</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started" target="_blank">&nbsp;&nbsp;&nbsp;Getting Started Docs</span></a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-installation" target="_blank">&nbsp;&nbsp;&nbsp;Installation Docs</a></li> 
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-administration" target="_blank">&nbsp;&nbsp;&nbsp;Administration Docs</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-release-notes" target="_blank">&nbsp;&nbsp;&nbsp;Release Notes</a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -93,13 +93,16 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="docs">Documentation <span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="docs">
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">Getting Started Docs</span></a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-installation" target="_blank">Installation Docs</a></li> 
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-administration" target="_blank">Administration Docs</a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-release-notes" target="_blank">Release Notes</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">CloudStack Documentation</span></a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Home" target="_blank">Wiki</a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+Books" target="_blank">Books</a></li>
                 <li><a tabindex="-1" href="api.html">API Documentation</a></li>
+                <li class="divider"></li>
+                <li><a tabindex="-1">Archived Documentation</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started" target="_blank">&nbsp;&nbsp;&nbsp;Getting Started Docs</span></a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-installation" target="_blank">&nbsp;&nbsp;&nbsp;Installation Docs</a></li> 
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-administration" target="_blank">&nbsp;&nbsp;&nbsp;Administration Docs</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-release-notes" target="_blank">&nbsp;&nbsp;&nbsp;Release Notes</a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/features.html
+++ b/content/features.html
@@ -93,13 +93,16 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="docs">Documentation <span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="docs">
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">Getting Started Docs</span></a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-installation" target="_blank">Installation Docs</a></li> 
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-administration" target="_blank">Administration Docs</a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-release-notes" target="_blank">Release Notes</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">CloudStack Documentation</span></a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Home" target="_blank">Wiki</a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+Books" target="_blank">Books</a></li>
                 <li><a tabindex="-1" href="api.html">API Documentation</a></li>
+                <li class="divider"></li>
+                <li><a tabindex="-1">Archived Documentation</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started" target="_blank">&nbsp;&nbsp;&nbsp;Getting Started Docs</span></a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-installation" target="_blank">&nbsp;&nbsp;&nbsp;Installation Docs</a></li> 
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-administration" target="_blank">&nbsp;&nbsp;&nbsp;Administration Docs</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-release-notes" target="_blank">&nbsp;&nbsp;&nbsp;Release Notes</a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/history.html
+++ b/content/history.html
@@ -93,13 +93,16 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="docs">Documentation <span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="docs">
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">Getting Started Docs</span></a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-installation" target="_blank">Installation Docs</a></li> 
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-administration" target="_blank">Administration Docs</a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-release-notes" target="_blank">Release Notes</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">CloudStack Documentation</span></a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Home" target="_blank">Wiki</a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+Books" target="_blank">Books</a></li>
                 <li><a tabindex="-1" href="api.html">API Documentation</a></li>
+                <li class="divider"></li>
+                <li><a tabindex="-1">Archived Documentation</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started" target="_blank">&nbsp;&nbsp;&nbsp;Getting Started Docs</span></a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-installation" target="_blank">&nbsp;&nbsp;&nbsp;Installation Docs</a></li> 
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-administration" target="_blank">&nbsp;&nbsp;&nbsp;Administration Docs</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-release-notes" target="_blank">&nbsp;&nbsp;&nbsp;Release Notes</a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/index.html
+++ b/content/index.html
@@ -93,13 +93,16 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="docs">Documentation <span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="docs">
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">Getting Started Docs</span></a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-installation" target="_blank">Installation Docs</a></li> 
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-administration" target="_blank">Administration Docs</a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-release-notes" target="_blank">Release Notes</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">CloudStack Documentation</span></a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Home" target="_blank">Wiki</a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+Books" target="_blank">Books</a></li>
                 <li><a tabindex="-1" href="api.html">API Documentation</a></li>
+                <li class="divider"></li>
+                <li><a tabindex="-1">Archived Documentation</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started" target="_blank">&nbsp;&nbsp;&nbsp;Getting Started Docs</span></a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-installation" target="_blank">&nbsp;&nbsp;&nbsp;Installation Docs</a></li> 
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-administration" target="_blank">&nbsp;&nbsp;&nbsp;Administration Docs</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-release-notes" target="_blank">&nbsp;&nbsp;&nbsp;Release Notes</a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/mailing-lists.html
+++ b/content/mailing-lists.html
@@ -93,13 +93,16 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="docs">Documentation <span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="docs">
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">Getting Started Docs</span></a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-installation" target="_blank">Installation Docs</a></li> 
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-administration" target="_blank">Administration Docs</a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-release-notes" target="_blank">Release Notes</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">CloudStack Documentation</span></a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Home" target="_blank">Wiki</a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+Books" target="_blank">Books</a></li>
                 <li><a tabindex="-1" href="api.html">API Documentation</a></li>
+                <li class="divider"></li>
+                <li><a tabindex="-1">Archived Documentation</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started" target="_blank">&nbsp;&nbsp;&nbsp;Getting Started Docs</span></a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-installation" target="_blank">&nbsp;&nbsp;&nbsp;Installation Docs</a></li> 
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-administration" target="_blank">&nbsp;&nbsp;&nbsp;Administration Docs</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-release-notes" target="_blank">&nbsp;&nbsp;&nbsp;Release Notes</a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/security.html
+++ b/content/security.html
@@ -93,13 +93,16 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="docs">Documentation <span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="docs">
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">Getting Started Docs</span></a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-installation" target="_blank">Installation Docs</a></li> 
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-administration" target="_blank">Administration Docs</a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-release-notes" target="_blank">Release Notes</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">CloudStack Documentation</span></a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Home" target="_blank">Wiki</a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+Books" target="_blank">Books</a></li>
                 <li><a tabindex="-1" href="api.html">API Documentation</a></li>
+                <li class="divider"></li>
+                <li><a tabindex="-1">Archived Documentation</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started" target="_blank">&nbsp;&nbsp;&nbsp;Getting Started Docs</span></a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-installation" target="_blank">&nbsp;&nbsp;&nbsp;Installation Docs</a></li> 
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-administration" target="_blank">&nbsp;&nbsp;&nbsp;Administration Docs</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-release-notes" target="_blank">&nbsp;&nbsp;&nbsp;Release Notes</a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/software.html
+++ b/content/software.html
@@ -93,13 +93,16 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="docs">Documentation <span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="docs">
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">Getting Started Docs</span></a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-installation" target="_blank">Installation Docs</a></li> 
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-administration" target="_blank">Administration Docs</a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-release-notes" target="_blank">Release Notes</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">CloudStack Documentation</span></a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Home" target="_blank">Wiki</a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+Books" target="_blank">Books</a></li>
                 <li><a tabindex="-1" href="api.html">API Documentation</a></li>
+                <li class="divider"></li>
+                <li><a tabindex="-1">Archived Documentation</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started" target="_blank">&nbsp;&nbsp;&nbsp;Getting Started Docs</span></a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-installation" target="_blank">&nbsp;&nbsp;&nbsp;Installation Docs</a></li> 
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-administration" target="_blank">&nbsp;&nbsp;&nbsp;Administration Docs</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-release-notes" target="_blank">&nbsp;&nbsp;&nbsp;Release Notes</a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/survey.html
+++ b/content/survey.html
@@ -93,13 +93,16 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="docs">Documentation <span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="docs">
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">Getting Started Docs</span></a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-installation" target="_blank">Installation Docs</a></li> 
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-administration" target="_blank">Administration Docs</a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-release-notes" target="_blank">Release Notes</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">CloudStack Documentation</span></a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Home" target="_blank">Wiki</a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+Books" target="_blank">Books</a></li>
                 <li><a tabindex="-1" href="api.html">API Documentation</a></li>
+                <li class="divider"></li>
+                <li><a tabindex="-1">Archived Documentation</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started" target="_blank">&nbsp;&nbsp;&nbsp;Getting Started Docs</span></a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-installation" target="_blank">&nbsp;&nbsp;&nbsp;Installation Docs</a></li> 
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-administration" target="_blank">&nbsp;&nbsp;&nbsp;Administration Docs</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-release-notes" target="_blank">&nbsp;&nbsp;&nbsp;Release Notes</a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/trademark-guidelines.html
+++ b/content/trademark-guidelines.html
@@ -93,13 +93,16 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="docs">Documentation <span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="docs">
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">Getting Started Docs</span></a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-installation" target="_blank">Installation Docs</a></li> 
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-administration" target="_blank">Administration Docs</a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-release-notes" target="_blank">Release Notes</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">CloudStack Documentation</span></a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Home" target="_blank">Wiki</a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+Books" target="_blank">Books</a></li>
                 <li><a tabindex="-1" href="api.html">API Documentation</a></li>
+                <li class="divider"></li>
+                <li><a tabindex="-1">Archived Documentation</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started" target="_blank">&nbsp;&nbsp;&nbsp;Getting Started Docs</span></a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-installation" target="_blank">&nbsp;&nbsp;&nbsp;Installation Docs</a></li> 
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-administration" target="_blank">&nbsp;&nbsp;&nbsp;Administration Docs</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-release-notes" target="_blank">&nbsp;&nbsp;&nbsp;Release Notes</a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/users.html
+++ b/content/users.html
@@ -93,13 +93,16 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="docs">Documentation <span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="docs">
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">Getting Started Docs</span></a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-installation" target="_blank">Installation Docs</a></li> 
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-administration" target="_blank">Administration Docs</a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-release-notes" target="_blank">Release Notes</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">CloudStack Documentation</span></a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Home" target="_blank">Wiki</a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+Books" target="_blank">Books</a></li>
                 <li><a tabindex="-1" href="api.html">API Documentation</a></li>
+                <li class="divider"></li>
+                <li><a tabindex="-1">Archived Documentation</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started" target="_blank">&nbsp;&nbsp;&nbsp;Getting Started Docs</span></a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-installation" target="_blank">&nbsp;&nbsp;&nbsp;Installation Docs</a></li> 
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-administration" target="_blank">&nbsp;&nbsp;&nbsp;Administration Docs</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-release-notes" target="_blank">&nbsp;&nbsp;&nbsp;Release Notes</a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/videos.html
+++ b/content/videos.html
@@ -93,13 +93,16 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="docs">Documentation <span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="docs">
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">Getting Started Docs</span></a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-installation" target="_blank">Installation Docs</a></li> 
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-administration" target="_blank">Administration Docs</a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-release-notes" target="_blank">Release Notes</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">CloudStack Documentation</span></a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Home" target="_blank">Wiki</a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+Books" target="_blank">Books</a></li>
                 <li><a tabindex="-1" href="api.html">API Documentation</a></li>
+                <li class="divider"></li>
+                <li><a tabindex="-1">Archived Documentation</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started" target="_blank">&nbsp;&nbsp;&nbsp;Getting Started Docs</span></a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-installation" target="_blank">&nbsp;&nbsp;&nbsp;Installation Docs</a></li> 
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-administration" target="_blank">&nbsp;&nbsp;&nbsp;Administration Docs</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-release-notes" target="_blank">&nbsp;&nbsp;&nbsp;Release Notes</a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/content/who.html
+++ b/content/who.html
@@ -93,13 +93,16 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="docs">Documentation <span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="docs">
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">Getting Started Docs</span></a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-installation" target="_blank">Installation Docs</a></li> 
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-administration" target="_blank">Administration Docs</a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-release-notes" target="_blank">Release Notes</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">CloudStack Documentation</span></a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Home" target="_blank">Wiki</a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+Books" target="_blank">Books</a></li>
                 <li><a tabindex="-1" href="api.html">API Documentation</a></li>
+                <li class="divider"></li>
+                <li><a tabindex="-1">Archived Documentation</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started" target="_blank">&nbsp;&nbsp;&nbsp;Getting Started Docs</span></a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-installation" target="_blank">&nbsp;&nbsp;&nbsp;Installation Docs</a></li> 
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-administration" target="_blank">&nbsp;&nbsp;&nbsp;Administration Docs</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-release-notes" target="_blank">&nbsp;&nbsp;&nbsp;Release Notes</a></li>
               </ul>
             </li>
             <li class="dropdown">

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -93,13 +93,16 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="docs">Documentation <span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="docs">
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">Getting Started Docs</span></a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-installation" target="_blank">Installation Docs</a></li> 
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-administration" target="_blank">Administration Docs</a></li>
-                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/cloudstack-release-notes" target="_blank">Release Notes</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org" target="_blank">CloudStack Documentation</span></a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/Home" target="_blank">Wiki</a></li>
                 <li><a tabindex="-1" href="https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+Books" target="_blank">Books</a></li>
                 <li><a tabindex="-1" href="api.html">API Documentation</a></li>
+                <li class="divider"></li>
+                <li><a tabindex="-1">Archived Documentation</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started" target="_blank">&nbsp;&nbsp;&nbsp;Getting Started Docs</span></a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-installation" target="_blank">&nbsp;&nbsp;&nbsp;Installation Docs</a></li> 
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-administration" target="_blank">&nbsp;&nbsp;&nbsp;Administration Docs</a></li>
+                <li><a tabindex="-1" href="http://docs.cloudstack.apache.org/projects/archived-cloudstack-release-notes" target="_blank">&nbsp;&nbsp;&nbsp;Release Notes</a></li>
               </ul>
             </li>
             <li class="dropdown">


### PR DESCRIPTION
PR to change Documentation dropdown to have a main link to consolidated documentation and additional links to older separate documentation

![image](https://user-images.githubusercontent.com/4810220/44044422-6949fc7c-9f1d-11e8-945b-e099958c7774.png)
