### PR TITLE
Remove Safe Swiss Cloud as a known user

### DIFF
--- a/source/users.html.markdown
+++ b/source/users.html.markdown
@@ -210,7 +210,6 @@ If you noticed something wrong with your entry here (or if you’d like us to re
 * RedBridge
 * RightScale, Inc.
 * Royal Melbourne Institute of Technology (RMIT)
-* Safe Swiss Cloud
 * SAP
 * Scalr
 * Schuberg Philis


### PR DESCRIPTION
Removing Safe Swiss Cloud as a known user because they do not use Apache CloudStack anymore.