### PR TITLE
Remove IRC reference as it is no longer used

### DIFF
--- a/source/contribute.html.markdown
+++ b/source/contribute.html.markdown
@@ -26,8 +26,4 @@ If you just want to report a bug, that's easily done in our [github project issu
 
 ## Where To Ask For Help
 
-Need some help getting started? Feel free to ask on the [mailing list](/mailing-lists.html) or find us on one of the following IRC channels on irc.freenode.net:
-
-* \#cloudstack - General Apache CloudStack conversation and end user support 
-* \#cloudstack-dev - Development discussions 
-* \#cloudstack-meeting - Weekly and ad-hoc meeting room for the Apache CloudStack community
+Need some help getting started? Feel free to ask on the [mailing list](/mailing-lists.html).


### PR DESCRIPTION
This PR addresses issue https://github.com/apache/cloudstack/issues/4880.

> Nowadays we mainly communicate via mailing list and Github issues/PRs. Additionally, the referenced IRC has no movement at all, and the fact that we are still marketing it as a point for discussions can give the wrong impression to newcomers, such as: "either the project is dead or documentation is outdated".