### PR TITLE
Inclusivity changes for CloudStack - Renamed default git branch name from 'master' to 'main', and some offensive words/terms as appropriate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,18 +26,18 @@ To serve it locally:
 
 # Important Update Information
 
-A few sections have been updated to be (more) dynamic.  The 'events' listed on the website are pulled from the CSV file in ./data/acs-events.csv .  The CSV that the website uses is the current raw file which is held in the Github master branch. Updates to this file are immediately 'visible' on the website.  There is no need to 'build' the website for the changes to become live. The format of the CSV is self explanatory, there is a heading row, please do not delete it, the processing on the web page assumes that it is there.  The 'latest announcements' section is pulled from the last 3 CloudStack blogs from the Apache Web site.
+A few sections have been updated to be (more) dynamic.  The 'events' listed on the website are pulled from the CSV file in ./data/acs-events.csv .  The CSV that the website uses is the current raw file which is held in the Github main branch. Updates to this file are immediately 'visible' on the website.  There is no need to 'build' the website for the changes to become live. The format of the CSV is self explanatory, there is a heading row, please do not delete it, the processing on the web page assumes that it is there.  The 'latest announcements' section is pulled from the last 3 CloudStack blogs from the Apache Web site.
 
 # Building
 To build the HTML files, you just need to execute the `build.sh`. The script will automatically generate the HTML files and then copy them to the `content` folder in preparation for being published via the `asf-site` branch.  Keep reading for detailed instructions.
 
 # Committing
 Use Github PRs to make changes to the live site. **No one should commit directly to the repositories without opening a PR and waiting for the proper review**.  
-Once the review process has been completed and the appropriate changes have been made to the PR, it is time to **commit** the changes.  Merging the PR into `master` will not publish the changes to the live website, the following steps are required to make the live site reflect the status of the `master` branch.
+Once the review process has been completed and the appropriate changes have been made to the PR, it is time to **commit** the changes.  Merging the PR into `main` will not publish the changes to the live website, the following steps are required to make the live site reflect the status of the `main` branch.
 
-**IMPORTANT:** In order to publish changes to the live site, you must commit into the `asf-site` branch.  It is very important that the `master` branch stays synchronized with the the `asf-site` branch.
+**IMPORTANT:** In order to publish changes to the live site, you must commit into the `asf-site` branch.  It is very important that the `main` branch stays synchronized with the the `asf-site` branch.
 
-The ASF maintains an integration which automatically publishes the content of the `asf-site` branch to a web server that serves the Apache CloudStack web pages.  It is important that both the `master` and `asf-site` branches track both the source and the resulting compiled content in order to simplify the management process.
+The ASF maintains an integration which automatically publishes the content of the `asf-site` branch to a web server that serves the Apache CloudStack web pages.  It is important that both the `main` and `asf-site` branches track both the source and the resulting compiled content in order to simplify the management process.
 
 NOTE: The content of the `build` directory needs to be copied to the `content` in the `asf-site` branch for the site to be served properly; If you use the `build.sh` script, this step is already taken care of.
 
@@ -51,9 +51,9 @@ NOTE: The content of the `build` directory needs to be copied to the `content` i
 
 **Sync Local with Upstream**
 ```bash
-git checkout master
+git checkout main
 git fetch upstream
-git pull upstream master
+git pull upstream main
 ```
 
 
@@ -71,25 +71,25 @@ middleman server [-p <portnumber>]
 ```bash
 git add .
 git commit -am "your commit message"
-git push origin master
+git push origin main
 ```
 
 
 **Create a PR**  
 * Confirm the changes appear correctly on your Github account.
-* Create a Pull Request against `master` on the `https://github.com/apache/cloudstack-www` repository.
+* Create a Pull Request against `main` on the `https://github.com/apache/cloudstack-www` repository.
 
 ---
 
 **COMMITTER: Validate a PR Locally**  
-Note: The following instructions assume the `<contributor>` made their changes on their `master` branch.
+Note: The following instructions assume the `<contributor>` made their changes on their `main` branch.
 
 ```bash
 # validate contributor changes
 cd /tmp
 git clone https://github.com/<contributor>/cloudstack-www.git
 cd cloudstack-www
-git checkout master
+git checkout main
 ./build.sh
 middleman server [-p <portnumber>]
 # visually validate changes at: http://localhost:[portnumber]
@@ -97,13 +97,13 @@ middleman server [-p <portnumber>]
 
 
 **COMMITTER: Merge & Deploy**  
-Merge the PR into `master` using the Github UI.
+Merge the PR into `main` using the Github UI.
 
-Once the PR has been merged into `master`, do the following to publish the content.
+Once the PR has been merged into `main`, do the following to publish the content.
 ```bash
 git fetch upstream
-git checkout master
-git pull upstream master
+git checkout main
+git pull upstream main
 ./build.sh  # updates the content directory
 middleman server [-p <portnumber>]
 # visually validate changes at: http://localhost:[portnumber]
@@ -112,10 +112,10 @@ git status
 # if there are untracked changes
 git add .
 git commit -am "updated PR#### to include compiled content"
-git push upstream master
-# if no untracked files or if you merged them into master
+git push upstream main
+# if no untracked files or if you merged them into main
 git checkout asf-site
-git merge master
+git merge main
 # run `middleman server [-p <portnumber>]` again and
 # validate the site updated at your `http://localhost:<portnumber>`
 git push upstream asf-site

--- a/content/cloudstack-faq.html
+++ b/content/cloudstack-faq.html
@@ -171,7 +171,7 @@
 
 <ul>
   <li><strong>Public</strong>: The template is available to all users in the zone.</li>
-  <li><strong>Private</strong>: The template is available only to its owner. A user can make her private templates available to specific users.</li>
+  <li><strong>Private</strong>: The template is available only to its owner. A user can make their private templates available to specific users.</li>
 </ul>
 
 <p>Administrators and end users can add templates to the system. Users can see the template owner when viewing the template.</p>

--- a/content/developers.html
+++ b/content/developers.html
@@ -153,7 +153,7 @@
 <p>Apache CloudStack has a read-only mirror on <a href="https://github.com/apache/cloudstack" target="_blank">GitHub</a> that is kept in sync with the 
 canonical Git repo maintained by the Apache Software Foundation. Submitting GitHub pull requests is the easiest way to get your contribution upstream. 
 For detailed instructions see the link below:<br />
-<a href="https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md" target="_blank">GitHub Contribution Guidelines</a></p>
+<a href="https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md" target="_blank">GitHub Contribution Guidelines</a></p>
 
 <h3>Submitting a patch</h3>
 
@@ -181,15 +181,15 @@ On your computer, follow these steps to setup a local repository for working on 
 $ git clone https://github.com/YOUR_ACCOUNT/cloudstack.git
 $ cd cloudstack
 $ git remote add upstream https://github.com/apache/cloudstack.git
-$ git checkout master
+$ git checkout main
 $ git fetch upstream
-$ git rebase upstream/master
+$ git rebase upstream/main
 </pre>
 
 <h4>Making Changes</h4>
 
 <p>It is important that you create a new branch to make changes on and that you do not change the 
-<code>master</code> branch (other than to rebase in changes from <code>upstream/master</code>).  In this example I will assume you will be making your changes 
+<code>main</code> branch (other than to rebase in changes from <code>upstream/main</code>).  In this example I will assume you will be making your changes 
 to a branch called <code>feature_x</code>. This <code>feature_x</code> branch will be created on your local repository and will be pushed to your
 forked repository on GitHub. Once this branch is on your fork you will create a Pull Request for the changes to be added to the ACS project.</p>
 
@@ -206,30 +206,30 @@ $ git commit -a -m "descriptive commit message for your changes"
 <blockquote>The <code>-b</code> specifies that you want to create a new branch called <code>feature_x</code>.  You only specify <code>-b</code> the first time you 
 checkout because you are creating a new branch.  Once the <code>feature_x</code> branch exists, you can later switch to it with only <code>git checkout feature_x</code>.</blockquote>
 
-<h4>Rebase <code>feature_x</code> to include updates from <code>upstream/master</code></h4>
+<h4>Rebase <code>feature_x</code> to include updates from <code>upstream/main</code></h4>
 
-<p>It is important that you maintain an up-to-date <code>master</code> branch in your local repository.  This is done by rebasing in the code 
-changes from <code>upstream/master</code> (the official ACS project repository) into your local repository.  You will want to do this before you start 
+<p>It is important that you maintain an up-to-date <code>main</code> branch in your local repository.  This is done by rebasing in the code 
+changes from <code>upstream/main</code> (the official ACS project repository) into your local repository.  You will want to do this before you start 
 working on a feature as well as right before you submit your changes as a pull request. We recommend you do this process periodically while you work to make 
 sure you are working off the most recent project code.</p>
 
 <p>This process will do the following:</p>
 
 <ol>
-  <li>Checkout your local <code>master</code> branch;</li>
-  <li>Synchronize your local <code>master</code> branch with the <code>upstream/master</code> so you have all the latest changes from the project;</li>
+  <li>Checkout your local <code>main</code> branch;</li>
+  <li>Synchronize your local <code>main</code> branch with the <code>upstream/main</code> so you have all the latest changes from the project;</li>
   <li>Rebase the latest project code into your <code>feature_x</code> branch so it is up-to-date with the upstream code.</li>
 </ol>
 
 <pre>
-$ git checkout master
+$ git checkout main
 $ git fetch upstream
-$ git rebase upstream/master
+$ git rebase upstream/main
 $ git checkout feature_x
-$ git rebase master
+$ git rebase main
 </pre>
 
-<blockquote>Now your <code>feature_x</code> branch is up-to-date with all the code in <code>upstream/master</code>.</blockquote>
+<blockquote>Now your <code>feature_x</code> branch is up-to-date with all the code in <code>upstream/main</code>.</blockquote>
 
 <h4>Make a GitHub pull request to contribute your changes</h4>
 
@@ -239,11 +239,11 @@ This is done by pushing your local changes to your forked repository (default re
 <p>Please include JIRA ID or GitHub ID, detailed information about the bug/feature, what all tests are executed, how the reviewer can test this
 feature etc. Incase of UI PRs, a screenshot is preferred.</p>
 
-<blockquote><b>IMPORTANT:</b>Make sure you have rebased your <code>feature_x</code> branch to include the latest code from <code>upstream/master</code> <b>before</b>
+<blockquote><b>IMPORTANT:</b>Make sure you have rebased your <code>feature_x</code> branch to include the latest code from <code>upstream/main</code> <b>before</b>
 you do this.</blockquote>
 
 <pre>
-$ git push origin master
+$ git push origin main
 $ git push origin feature_x
 </pre>
 
@@ -254,7 +254,7 @@ $ git push origin feature_x
 <ol>
 <li>In your browser, navigate to your forked repository: <b>https://github.com/YOUR_ACCOUNT/cloudstack</b>;</li>
 <li>Click the new button called '<b>Compare &amp; pull request</b>' that showed up just above the main area in your forked repository;</li>
-<li>Validate the pull request will be into the upstream <code>master</code> and will be from your <code>feature_x</code> branch;</li>
+<li>Validate the pull request will be into the upstream <code>main</code> and will be from your <code>feature_x</code> branch;</li>
 <li>Enter a detailed description of the work you have done and then click '<b>Send pull request</b>'.</li>
 </ol>
 
@@ -263,16 +263,16 @@ the <code>feature_x</code> branch to your fork. The existing pull request should
 
 <h4>Cleaning up after a successful pull request</h4>
 
-<p>Once the <code>feature_x</code> branch has been committed into the <code>upstream/master</code> branch, your local <code>feature_x</code> branch
+<p>Once the <code>feature_x</code> branch has been committed into the <code>upstream/main</code> branch, your local <code>feature_x</code> branch
 and the <code>origin/feature_x</code> branch are no longer needed. If you want to make additional changes, restart the process with a new branch.</p>
 
-<blockquote><b>IMPORTANT:</b>Make sure that your changes are in <code>upstream/master</code>before you delete your <code>feature_x</code>
+<blockquote><b>IMPORTANT:</b>Make sure that your changes are in <code>upstream/main</code>before you delete your <code>feature_x</code>
 and <code>origin/feature_x</code> branches!</blockquote>
 
 <p>You can delete these deprecated branches with the following:</p>
 
 <pre>
-$ git checkout master
+$ git checkout main
 $ git branch -D feature_x
 $ git push origin :feature_x
 </pre>
@@ -294,7 +294,7 @@ endings (LF) rather than Windows-type line endings (CRLF).</p>
 
 <a href="https://github.com/apache/cloudstack/" class="list-group-item" target="_blank">Public repository (on github)</a>
 
-<a hread="https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md" class="list-group-item" target="_blank">Contribution Guidelines</a>
+<a hread="https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md" class="list-group-item" target="_blank">Contribution Guidelines</a>
 
 <a href="https://builds.apache.org/view/A-D/view/Cloudstack/" class="list-group-item" target="_blank">ASF Jenkins</a>
 

--- a/content/index.html
+++ b/content/index.html
@@ -274,7 +274,7 @@
     $.ajax({
       type: "GET",
       // github controlled datasource
-      url: "https://raw.githubusercontent.com/apache/cloudstack-www/master/data/acs-events.csv",
+      url: "https://raw.githubusercontent.com/apache/cloudstack-www/main/data/acs-events.csv",
       dataType: "text",
       success: function(data) {processData(data);}
     });

--- a/content/users.html
+++ b/content/users.html
@@ -140,11 +140,11 @@
 
 <h2 id="how-to-add-your-company-in-the-list">How to Add your Company in The List</h2>
 
-<p>If you are using CloudStack in your organisation and your company is not listed here, please send a pull request to the GitHub <a href="https://github.com/apache/cloudstack-www/blob/master/source/users.html.markdown">page</a>.</p>
+<p>If you are using CloudStack in your organisation and your company is not listed here, please send a pull request to the GitHub <a href="https://github.com/apache/cloudstack-www/blob/main/source/users.html.markdown">page</a>.</p>
 
 <h2 id="how-to-request-the-entry-removal-or-change">How to Request the Entry Removal or Change</h2>
 
-<p>If you noticed something wrong with your entry here (or if you’d like us to remove it), please send a pull request to the GitHub <a href="https://github.com/apache/cloudstack-www/blob/master/source/users.html.markdown">page</a> or write your concerns to the mail-list <strong>users@cloudstack.apache.org</strong>.</p>
+<p>If you noticed something wrong with your entry here (or if you’d like us to remove it), please send a pull request to the GitHub <a href="https://github.com/apache/cloudstack-www/blob/main/source/users.html.markdown">page</a> or write your concerns to the mail-list <strong>users@cloudstack.apache.org</strong>.</p>
 
 <ul>
   <li><a href="http://www.actonmagic.com">ActOnMagic</a></li>

--- a/source/developers.html.markdown
+++ b/source/developers.html.markdown
@@ -35,7 +35,7 @@ title: Developer Resources for Apache CloudStack
 <p>Apache CloudStack has a read-only mirror on <a href="https://github.com/apache/cloudstack" target="_blank">GitHub</a> that is kept in sync with the 
 canonical Git repo maintained by the Apache Software Foundation. Submitting GitHub pull requests is the easiest way to get your contribution upstream. 
 For detailed instructions see the link below:<br />
-<a href="https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md" target="_blank">GitHub Contribution Guidelines</a></p>
+<a href="https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md" target="_blank">GitHub Contribution Guidelines</a></p>
 
 <h3>Submitting a patch</h3>
 
@@ -63,15 +63,15 @@ On your computer, follow these steps to setup a local repository for working on 
 $ git clone https://github.com/YOUR_ACCOUNT/cloudstack.git
 $ cd cloudstack
 $ git remote add upstream https://github.com/apache/cloudstack.git
-$ git checkout master
+$ git checkout main
 $ git fetch upstream
-$ git rebase upstream/master
+$ git rebase upstream/main
 </pre>
 
 <h4>Making Changes</h4>
 
 <p>It is important that you create a new branch to make changes on and that you do not change the 
-<code>master</code> branch (other than to rebase in changes from <code>upstream/master</code>).  In this example I will assume you will be making your changes 
+<code>main</code> branch (other than to rebase in changes from <code>upstream/main</code>).  In this example I will assume you will be making your changes 
 to a branch called <code>feature_x</code>. This <code>feature_x</code> branch will be created on your local repository and will be pushed to your
 forked repository on GitHub. Once this branch is on your fork you will create a Pull Request for the changes to be added to the ACS project.</p>
 
@@ -88,30 +88,30 @@ $ git commit -a -m "descriptive commit message for your changes"
 <blockquote>The <code>-b</code> specifies that you want to create a new branch called <code>feature_x</code>.  You only specify <code>-b</code> the first time you 
 checkout because you are creating a new branch.  Once the <code>feature_x</code> branch exists, you can later switch to it with only <code>git checkout feature_x</code>.</blockquote>
 
-<h4>Rebase <code>feature_x</code> to include updates from <code>upstream/master</code></h4>
+<h4>Rebase <code>feature_x</code> to include updates from <code>upstream/main</code></h4>
 
-<p>It is important that you maintain an up-to-date <code>master</code> branch in your local repository.  This is done by rebasing in the code 
-changes from <code>upstream/master</code> (the official ACS project repository) into your local repository.  You will want to do this before you start 
+<p>It is important that you maintain an up-to-date <code>main</code> branch in your local repository.  This is done by rebasing in the code 
+changes from <code>upstream/main</code> (the official ACS project repository) into your local repository.  You will want to do this before you start 
 working on a feature as well as right before you submit your changes as a pull request. We recommend you do this process periodically while you work to make 
 sure you are working off the most recent project code.</p>
 
 <p>This process will do the following:</p>
 
 <ol>
-  <li>Checkout your local <code>master</code> branch;</li>
-  <li>Synchronize your local <code>master</code> branch with the <code>upstream/master</code> so you have all the latest changes from the project;</li>
+  <li>Checkout your local <code>main</code> branch;</li>
+  <li>Synchronize your local <code>main</code> branch with the <code>upstream/main</code> so you have all the latest changes from the project;</li>
   <li>Rebase the latest project code into your <code>feature_x</code> branch so it is up-to-date with the upstream code.</li>
 </ol>
 
 <pre>
-$ git checkout master
+$ git checkout main
 $ git fetch upstream
-$ git rebase upstream/master
+$ git rebase upstream/main
 $ git checkout feature_x
-$ git rebase master
+$ git rebase main
 </pre>
 
-<blockquote>Now your <code>feature_x</code> branch is up-to-date with all the code in <code>upstream/master</code>.</blockquote>
+<blockquote>Now your <code>feature_x</code> branch is up-to-date with all the code in <code>upstream/main</code>.</blockquote>
 
 <h4>Make a GitHub pull request to contribute your changes</h4>
 
@@ -121,11 +121,11 @@ This is done by pushing your local changes to your forked repository (default re
 <p>Please include JIRA ID or GitHub ID, detailed information about the bug/feature, what all tests are executed, how the reviewer can test this
 feature etc. Incase of UI PRs, a screenshot is preferred.</p>
 
-<blockquote><b>IMPORTANT:</b>Make sure you have rebased your <code>feature_x</code> branch to include the latest code from <code>upstream/master</code> <b>before</b>
+<blockquote><b>IMPORTANT:</b>Make sure you have rebased your <code>feature_x</code> branch to include the latest code from <code>upstream/main</code> <b>before</b>
 you do this.</blockquote>
 
 <pre>
-$ git push origin master
+$ git push origin main
 $ git push origin feature_x
 </pre>
 
@@ -136,7 +136,7 @@ $ git push origin feature_x
 <ol>
 <li>In your browser, navigate to your forked repository: <b>https://github.com/YOUR_ACCOUNT/cloudstack</b>;</li>
 <li>Click the new button called '<b>Compare & pull request</b>' that showed up just above the main area in your forked repository;</li>
-<li>Validate the pull request will be into the upstream <code>master</code> and will be from your <code>feature_x</code> branch;</li>
+<li>Validate the pull request will be into the upstream <code>main</code> and will be from your <code>feature_x</code> branch;</li>
 <li>Enter a detailed description of the work you have done and then click '<b>Send pull request</b>'.</li>
 </ol>
 
@@ -145,16 +145,16 @@ the <code>feature_x</code> branch to your fork. The existing pull request should
 
 <h4>Cleaning up after a successful pull request</h4>
 
-<p>Once the <code>feature_x</code> branch has been committed into the <code>upstream/master</code> branch, your local <code>feature_x</code> branch
+<p>Once the <code>feature_x</code> branch has been committed into the <code>upstream/main</code> branch, your local <code>feature_x</code> branch
 and the <code>origin/feature_x</code> branch are no longer needed. If you want to make additional changes, restart the process with a new branch.</p>
 
-<blockquote><b>IMPORTANT:</b>Make sure that your changes are in <code>upstream/master</code>before you delete your <code>feature_x</code>
+<blockquote><b>IMPORTANT:</b>Make sure that your changes are in <code>upstream/main</code>before you delete your <code>feature_x</code>
 and <code>origin/feature_x</code> branches!</blockquote>
 
 <p>You can delete these deprecated branches with the following:</p>
 
 <pre>
-$ git checkout master
+$ git checkout main
 $ git branch -D feature_x
 $ git push origin :feature_x
 </pre>
@@ -176,7 +176,7 @@ endings (LF) rather than Windows-type line endings (CRLF).</p>
 
 <a href="https://github.com/apache/cloudstack/" class="list-group-item" target="_blank">Public repository (on github)</a>
 
-<a hread="https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md" class="list-group-item" target="_blank">Contribution Guidelines</a>
+<a hread="https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md" class="list-group-item" target="_blank">Contribution Guidelines</a>
 
 <a href="https://builds.apache.org/view/A-D/view/Cloudstack/" class="list-group-item" target="_blank">ASF Jenkins</a>
 

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -166,7 +166,7 @@ title: Welcome to CloudStack
     $.ajax({
       type: "GET",
       // github controlled datasource
-      url: "https://raw.githubusercontent.com/apache/cloudstack-www/master/data/acs-events.csv",
+      url: "https://raw.githubusercontent.com/apache/cloudstack-www/main/data/acs-events.csv",
       dataType: "text",
       success: function(data) {processData(data);}
     });

--- a/source/users.html.markdown
+++ b/source/users.html.markdown
@@ -22,11 +22,11 @@ Our users include many major service providers running CloudStack to offer publi
 
 ## How to Add your Company in The List
 
-If you are using CloudStack in your organisation and your company is not listed here, please send a pull request to the GitHub [page](https://github.com/apache/cloudstack-www/blob/master/source/users.html.markdown).
+If you are using CloudStack in your organisation and your company is not listed here, please send a pull request to the GitHub [page](https://github.com/apache/cloudstack-www/blob/main/source/users.html.markdown).
 
 ## How to Request the Entry Removal or Change
 
-If you noticed something wrong with your entry here (or if you’d like us to remove it), please send a pull request to the GitHub [page](https://github.com/apache/cloudstack-www/blob/master/source/users.html.markdown) or write your concerns to the mail-list **users@cloudstack.apache.org**.
+If you noticed something wrong with your entry here (or if you’d like us to remove it), please send a pull request to the GitHub [page](https://github.com/apache/cloudstack-www/blob/main/source/users.html.markdown) or write your concerns to the mail-list **users@cloudstack.apache.org**.
 
 * [ActOnMagic](http://www.actonmagic.com)
 * [Appcore](http://www.appcore.com)


### PR DESCRIPTION
Inclusivity changes for CloudStack -  Renamed default git branch name from 'master' to 'main', and some offensive words/terms as appropriate.