### PR TITLE
Fixing api link in about page

### DIFF
--- a/content/about.html
+++ b/content/about.html
@@ -142,7 +142,7 @@
 <ul>
   <li>Works with hosts running XenServer/XCP, KVM, Hyper-V, and/or VMware ESXi with vSphere</li>
   <li>Provides a friendly Web-based UI for managing the cloud</li>
-  <li>Provides a native <a href="/docs/api/">API</a></li>
+  <li>Provides a native <a href="api.html">API</a></li>
   <li>May provide an Amazon S3/EC2 compatible API (optional)</li>
   <li>Manages storage for instances running on the hypervisors (primary storage) as well as templates, snapshots, and ISO images (secondary storage)</li>
   <li>Orchestrates network services from the data link layer (L2) to some application layer (L7) services, such as DHCP, NAT, firewall, VPN, and so on</li>


### PR DESCRIPTION
Currently the website's about page points to an invalid url. Changed it to match the api link from the dropdown.