### PR TITLE
Use dynamic `year` for `Copyright` in `docusaurus.config.js`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013 - 2021 The Apache Software Foundation
+Copyright (c) 2013 - 2024 The Apache Software Foundation
 
 
                                  Apache License

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -252,7 +252,7 @@ const config = {
 		  <img src="/img/linkedin_icon.svg" alt=""/>
 		</a>
             </div>
-            <div class="footer-bottom">Copyright © 2023 The Apache
+            <div class="footer-bottom">Copyright © ${new Date().getFullYear()} The Apache
 Software Foundation, Licensed under the Apache License, Version 2.0.
 “Apache”, “CloudStack”, “Apache CloudStack”, the Apache CloudStack logo,
  the Apache CloudStack Cloud Monkey logo and the Apache feather logos

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -252,7 +252,7 @@ const config = {
 		  <img src="/img/linkedin_icon.svg" alt=""/>
 		</a>
             </div>
-            <div class="footer-bottom">Copyright © 2012-${new Date().getFullYear()} The Apache
+            <div class="footer-bottom">Copyright © 2013  - ${new Date().getFullYear()} The Apache
 Software Foundation, Licensed under the Apache License, Version 2.0.
 “Apache”, “CloudStack”, “Apache CloudStack”, the Apache CloudStack logo,
  the Apache CloudStack Cloud Monkey logo and the Apache feather logos

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -252,7 +252,7 @@ const config = {
 		  <img src="/img/linkedin_icon.svg" alt=""/>
 		</a>
             </div>
-            <div class="footer-bottom">Copyright © 2013  - ${new Date().getFullYear()} The Apache
+            <div class="footer-bottom">Copyright © 2012  - ${new Date().getFullYear()} The Apache
 Software Foundation, Licensed under the Apache License, Version 2.0.
 “Apache”, “CloudStack”, “Apache CloudStack”, the Apache CloudStack logo,
  the Apache CloudStack Cloud Monkey logo and the Apache feather logos

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -252,7 +252,7 @@ const config = {
 		  <img src="/img/linkedin_icon.svg" alt=""/>
 		</a>
             </div>
-            <div class="footer-bottom">Copyright © ${new Date().getFullYear()} The Apache
+            <div class="footer-bottom">Copyright © 2012-${new Date().getFullYear()} The Apache
 Software Foundation, Licensed under the Apache License, Version 2.0.
 “Apache”, “CloudStack”, “Apache CloudStack”, the Apache CloudStack logo,
  the Apache CloudStack Cloud Monkey logo and the Apache feather logos


### PR DESCRIPTION
Also update the main license to 2024

Example seen here:

https://docusaurus.io/docs/api/docusaurus-config#themeConfig