### PR TITLE
Fix reference to Roket Cloud

### DIFF
--- a/src/pages/users.mdx
+++ b/src/pages/users.mdx
@@ -56,7 +56,7 @@ mailing list <b>users@cloudstack.apache.org</b>.
 - [Polcom](http://polcom.com.pl)
 - [Reliable Networks](http://www.reliablenetworks.com)
 - [Redbridge](http://www.redbridge.se)
-- [Roket Cloud] (https://roket.cloud)
+- [Roket Cloud](https://roket.cloud)
 - [SafeSwiss Cloud](https://www.safeswisscloud.ch)
 - [HIAG Data AG](https://www.hiagdata.com)
 - [SJC Inc](http://www.sjcloud.cn/index.xhtml)


### PR DESCRIPTION

This fixes references introduced by https://github.com/apache/cloudstack-www/pull/210/
Fixes: https://github.com/apache/cloudstack-www/blob/staging-site/src/pages/users.mdx?plain=1#L59