### PR TITLE
Fix AssignToLoadBalancerRule input

### DIFF
--- a/static/api/apidocs-4.16/apis/assignToLoadBalancerRule.html
+++ b/static/api/apidocs-4.16/apis/assignToLoadBalancerRule.html
@@ -49,7 +49,7 @@
                                             <td style="width:200px;"><i>virtualmachineids</i></td><td style="width:500px;"><i>the list of IDs of the virtual machine that are being assigned to the load balancer rule(i.e. virtualMachineIds=1,2,3)</i></td><td style="width:180px;"><i>false</i></td>
                                         </tr>
                                         <tr>
-                                            <td style="width:200px;"><i>vmidipmap</i></td><td style="width:500px;"><i>VM ID and IP map, vmidipmap[0].vmid=1 vmidipmap[0].ip=10.1.1.75</i></td><td style="width:180px;"><i>false</i></td>
+                                            <td style="width:200px;"><i>vmidipmap</i></td><td style="width:500px;"><i>VM ID and IP map, vmidipmap[0].vmid=1 vmidipmap[0].vmip=10.1.1.75</i></td><td style="width:180px;"><i>false</i></td>
                                         </tr>
                                     </table>
                                 </div>

--- a/static/api/apidocs-4.17/apis/assignToLoadBalancerRule.html
+++ b/static/api/apidocs-4.17/apis/assignToLoadBalancerRule.html
@@ -49,7 +49,7 @@
                                             <td style="width:200px;"><i>virtualmachineids</i></td><td style="width:500px;"><i>the list of IDs of the virtual machine that are being assigned to the load balancer rule(i.e. virtualMachineIds=1,2,3)</i></td><td style="width:180px;"><i>false</i></td>
                                         </tr>
                                         <tr>
-                                            <td style="width:200px;"><i>vmidipmap</i></td><td style="width:500px;"><i>VM ID and IP map, vmidipmap[0].vmid=1 vmidipmap[0].ip=10.1.1.75</i></td><td style="width:180px;"><i>false</i></td>
+                                            <td style="width:200px;"><i>vmidipmap</i></td><td style="width:500px;"><i>VM ID and IP map, vmidipmap[0].vmid=1 vmidipmap[0].vmip=10.1.1.75</i></td><td style="width:180px;"><i>false</i></td>
                                         </tr>
                                     </table>
                                 </div>

--- a/static/api/apidocs-4.18/apis/assignToLoadBalancerRule.html
+++ b/static/api/apidocs-4.18/apis/assignToLoadBalancerRule.html
@@ -49,7 +49,7 @@
                                             <td style="width:200px;"><i>virtualmachineids</i></td><td style="width:500px;"><i>the list of IDs of the virtual machine that are being assigned to the load balancer rule(i.e. virtualMachineIds=1,2,3)</i></td><td style="width:180px;"><i>false</i></td>
                                         </tr>
                                         <tr>
-                                            <td style="width:200px;"><i>vmidipmap</i></td><td style="width:500px;"><i>VM ID and IP map, vmidipmap[0].vmid=1 vmidipmap[0].ip=10.1.1.75</i></td><td style="width:180px;"><i>false</i></td>
+                                            <td style="width:200px;"><i>vmidipmap</i></td><td style="width:500px;"><i>VM ID and IP map, vmidipmap[0].vmid=1 vmidipmap[0].vmip=10.1.1.75</i></td><td style="width:180px;"><i>false</i></td>
                                         </tr>
                                     </table>
                                 </div>

--- a/static/api/apidocs-4.19/apis/assignToLoadBalancerRule.html
+++ b/static/api/apidocs-4.19/apis/assignToLoadBalancerRule.html
@@ -49,7 +49,7 @@
                                             <td style="width:200px;"><i>virtualmachineids</i></td><td style="width:500px;"><i>the list of IDs of the virtual machine that are being assigned to the load balancer rule(i.e. virtualMachineIds=1,2,3)</i></td><td style="width:180px;"><i>false</i></td>
                                         </tr>
                                         <tr>
-                                            <td style="width:200px;"><i>vmidipmap</i></td><td style="width:500px;"><i>VM ID and IP map, vmidipmap[0].vmid=1 vmidipmap[0].ip=10.1.1.75</i></td><td style="width:180px;"><i>false</i></td>
+                                            <td style="width:200px;"><i>vmidipmap</i></td><td style="width:500px;"><i>VM ID and IP map, vmidipmap[0].vmid=1 vmidipmap[0].vmip=10.1.1.75</i></td><td style="width:180px;"><i>false</i></td>
                                         </tr>
                                     </table>
                                 </div>


### PR DESCRIPTION
the AssignToLoadBalancerRule has vmidipmap[0].vmip as input but in the description mentioned vmidipmap[0].ip incrrectly.
 fix PR on Cloudstack: https://github.com/apache/cloudstack/pull/9306