### PR TITLE
make link to /security more prominent

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -90,10 +90,6 @@ const config = {
               {
                 label: 'Trademark Guidelines',
                 href: '/trademark-guidelines'
-              },
-              {
-                label: 'Security',
-                href: '/security'
               }
             ]
           },


### PR DESCRIPTION
Remove the link to https://apache.org/security from the top-level menu since we want people to first find the About>Security link pointing to the project-specific security information at
https://cloudstack.apache.org/security . The Apache-wide information is linked from there.