### PR TITLE
make link to /security more prominent

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -94,6 +94,10 @@ const config = {
               {
                 label: 'Trademark Guidelines',
                 href: '/trademark-guidelines'
+              },
+              {
+                label: 'Security',
+                href: '/security'
               }
             ]
           },
@@ -216,7 +220,6 @@ const config = {
               {label: 'Foundation', to: 'https://www.apache.org/'},
               {label: 'License', to: 'https://www.apache.org/licenses/'},
               {label: 'Events', to: 'https://www.apache.org/events/current-event'},
-              {label: 'Security', to: 'https://www.apache.org/security/'},
               {label: 'Sponsorship', to: 'https://www.apache.org/foundation/sponsorship.html'},
               {label: 'Privacy', to: 'https://www.apache.org/foundation/policies/privacy.html'},
               {label: 'Thanks', to: 'https://www.apache.org/foundation/thanks.html'}


### PR DESCRIPTION
This reverts commit bdf5c2ad21939612f5213b461300ce83f9022ea9 / #224 and instead removes the 'other' link, because it did the exact opposite of what the description promised it'd do.