### PR TITLE
Fix alignment of past events buttons

### DIFF
--- a/src/components/Events/index.tsx
+++ b/src/components/Events/index.tsx
@@ -103,7 +103,7 @@ involved with the community.
                   <p className="events-info"><img src="img/calendar_icon.png" className="me-2" alt=""/>February 22, 2024</p>
                 </div>
                 <div className="col-lg-3 px-4 events-btn-margin d-flex justify-content-center justify-content-lg-end align-items-center">
-                  <a href="https://www.youtube.com/playlist?list=PLnIKk7GjgFlYgPbjM3os1YoE10Ys9gEB6" className="btn btn-primary">Watch</a>
+                  <a href="https://www.youtube.com/playlist?list=PLnIKk7GjgFlYgPbjM3os1YoE10Ys9gEB6" className="btn btn-primary me-3">Watch</a>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Fixes alignment of buttons on the Past Events section.

Before:
![image](https://github.com/user-attachments/assets/77887e13-9c5a-4b39-9083-d4f53847e186)

After:
![image](https://github.com/user-attachments/assets/3620d19f-35c2-402c-96e3-b93b9fa124cb)
