### PR TITLE
Slack footer   (Automated mailto users@cloudstack.apache.org to join Slack Community)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -239,7 +239,7 @@ const config = {
                 <a href="mailto:dev-subscribe@cloudstack.apache.org">
 		  <img src="/img/mail_mini_icon.svg" alt=""/>
 		</a>
-                <a href="https://join.slack.com/t/apachecloudstack/shared_invite/zt-2aegc22z7-tPCxpptfcebTBtd59qcZSQ" target="_blank">
+                <a href="mailto:users@cloudstack.apache.org?subject=Request%20to%20join%20Slack%20community&body=Thanks,%0A%0ARegards." target="_blank">
 		  <img src="/img/slack_mini_icon.svg" alt=""/>
 		</a>
                 <a href="https://github.com/apache/cloudstack" target="_blank">


### PR DESCRIPTION
Slack community join button has not yet been updated to reflect the changes introduced in PR #306 .
The button should send a request to user@cloudstack.apache.org to request an invite to join the Slack community, rather than using the outdated direct invite link. This update aligns with the intended functionality outlined in PR #306 , which addresses issues #202 and #305.