### PR TITLE
Homepage: fix 404 broken image for YOTTA

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -38,7 +38,7 @@ Apache CloudStack™  is an open-source software system designed to deploy and m
           <img src="/img/brainboard.png" height="25" alt=""/>
           <img src="/img/ntt.svg" height="18" alt=""/>
           <img src="/img/leaseweb.svg" height="25" alt=""/>
-          <img src="/img/logo-yotta .png" height="20" alt=""/>
+          <img src="/img/logo-yotta.png" height="20" alt=""/>
           <img src="/img/Logo_arsat.png" height="20" alt=""/>
           <img src="/img/we_systems.svg" height="50" alt=""/>
           <img src="/img/AT&T_logo_2016.svg" height="38" alt=""/>


### PR DESCRIPTION
<img width="1944" height="1233" alt="missing-logo-yotta" src="https://github.com/user-attachments/assets/a1228df8-ca99-458f-8dfb-bc39b8ec691b" />
