### PR TITLE
[INFRA] Set up default rulesets for default and release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -29,26 +29,39 @@ github:
     - infrastructure
     - hosting
   enabled_merge_buttons:
-    squash:  true
-    merge:   false
-    rebase:  false
+    squash: true
+    merge: false
+    rebase: false
 
-  protected_branches: ~
+  protected_branches:
 
   collaborators:
     - acs-robot
     - jamiepell10
 
+  rulesets:
+    - name: "Default Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+          - "release/*"
+          - "rel/*"
+        excludes: []
+      bypass_teams:
+        - root
+      restrict_deletion: true
+      restrict_force_push: true
 notifications:
-  commits:      commits@cloudstack.apache.org
-  issues:       issues@cloudstack.apache.org
+  commits: commits@cloudstack.apache.org
+  issues: issues@cloudstack.apache.org
   pullrequests: issues@cloudstack.apache.org
-  jobs:         commits@cloudstack.apache.org
+  jobs: commits@cloudstack.apache.org
 
 # Staging and publishing profile for cloudstack-www.git:
 staging:
-  profile: ~
+  profile:
   whoami: staged-site
 
 publish:
-  whoami:  asf-site
+  whoami: asf-site


### PR DESCRIPTION
This Pull Request enables the repository to conform with the "sane default security settings" of the Apache Software Foundation by configuring a default branch ruleset that protects the default branch and any release branches.

Note that `~DEFAULT_BRANCH` is a GitHub symbolic link to the current default branch (HEAD) of the repository and does not need changing.
If the managing project does not wish to set up these defaults, please close this Pull Request. Alternatively, the project may merge this Pull Request to apply the changes immediately.

If no action is taken, this Pull Request will be automatically merged by the Apache Infrastructure team on **2026-06-14** (30 days from now).

For any further information, please reach us on Slack or at: users@infra.apache.org
