### PR TITLE
Add a quote to the version 24 announcement and fix its Markdown lists

### DIFF
--- a/blog/2026-09-03-next-release-is-24/index.md
+++ b/blog/2026-09-03-next-release-is-24/index.md
@@ -47,6 +47,14 @@ So the version we publish now matches the version people actually use. It also
 removes a question that kept coming back, which is what a major version bump
 would even mean for CloudStack.
 
+>“We dropped the "4." because it stopped meaning anything years ago, not
+>because anything changed. CloudStack is a mature platform, this change signals
+>that. It has been running production clouds for more than 10 years and has
+>been an Apache Software Foundation project since 2013. It just works. That
+>stability is not a vendor promise, it is how the project is governed.”
+>
+>-Wido den Hollander, PMC Member, Apache CloudStack
+
 ## What you may need to check
 
 · If you have tooling, scripts or monitoring that parses the CloudStack version

--- a/blog/2026-09-03-next-release-is-24/index.md
+++ b/blog/2026-09-03-next-release-is-24/index.md
@@ -13,25 +13,18 @@ that would have been 4.24 will be released as 24. The "4." prefix is gone.
 
 ## What changes
 
-· The next feature release is 24, with the full version 24.0.0
-
-· Maintenance releases on that branch become 24.1.0, 24.2.0, and so on
-
-· Feature releases after that become 25, 26, 27
-
-· The branch is called 24, packages and tarballs will say 24.0.0
+- The next feature release is 24, with the full version 24.0.0
+- Maintenance releases on that branch become 24.1.0, 24.2.0, and so on
+- Feature releases after that become 25, 26, 27
+- The branch is called 24, packages and tarballs will say 24.0.0
 
 ## What does not change
 
-· 4.23 is not affected. It was released as planned under the old scheme
-
-· The release cadence stays the same
-
-· The LTS policy stays the same
-
-· The branching and release process stays the same
-
-· The backwards compatibility guarantees stay the same
+- 4.23 is not affected. It was released as planned under the old scheme
+- The release cadence stays the same
+- The LTS policy stays the same
+- The branching and release process stays the same
+- The backwards compatibility guarantees stay the same
 
 Dropping the "4." is not a signal that 24 breaks APIs or brings disruptive
 changes. It is a naming change and nothing else.
@@ -57,13 +50,11 @@ would even mean for CloudStack.
 
 ## What you may need to check
 
-· If you have tooling, scripts or monitoring that parses the CloudStack version
+- If you have tooling, scripts or monitoring that parses the CloudStack version
   and assumes it starts with "4.", update it. A version can now be three
   numbers, such as 24.0.0
-
-· Repository paths and package names will use 24.x once 24.0.0 is out
-
-· The upgrade path itself is unchanged. Upgrading from 4.23 to 24 works the same
+- Repository paths and package names will use 24.x once 24.0.0 is out
+- The upgrade path itself is unchanged. Upgrading from 4.23 to 24 works the same
   way any other upgrade does
 
 ## How this was decided


### PR DESCRIPTION
Two changes to the [version 24 announcement post](https://cloudstack.apache.org/blog/next-release-is-24).

### Add a quote

Adds a short quote to the `Why` section that can be reused in marketing
material. It explains briefly why the `4.` prefix was dropped and frames the
change as a signal of the project's maturity and long term stability under the
Apache Software Foundation.

### Fix the Markdown lists

The three lists in the post used a literal middle dot character (`·`) instead
of Markdown bullets, so they rendered as plain paragraphs rather than list
items. Converted them to standard `-` bullets, matching the rest of the blog.